### PR TITLE
Fix ForceTextToStrCommand when other imports are present in the file

### DIFF
--- a/django_codemod/codemods/django_40.py
+++ b/django_codemod/codemods/django_40.py
@@ -20,26 +20,27 @@ class ForceTextToStrCommand(VisitorBasedCodemodCommand):
     ) -> Union[BaseSmallStatement, RemovalSentinel]:
         if updated_node.module and len(updated_node.module.children) == 3:
             tops, _, last = updated_node.module.children
-            top, _, middle = tops.children
-            if (
-                top.value == "django"
-                and middle.value == "utils"
-                and last.value == "encoding"
-            ):
-                new_names = []
-                new_import_missing = True
-                new_import_alias = None
-                for import_alias in original_node.names:
-                    if import_alias.evaluated_name == "force_text":
-                        new_import_alias = ImportAlias(name=Name("force_str"))
-                    else:
-                        if import_alias.evaluated_name == "force_str":
-                            new_import_missing = False
-                        new_names.append(import_alias)
-                if new_import_missing and new_import_alias is not None:
-                    new_names.append(new_import_alias)
-                new_names = list(sorted(new_names, key=lambda n: n.evaluated_name))
-                return ImportFrom(module=updated_node.module, names=new_names)
+            if len(tops.children) == 3:
+                top, _, middle = tops.children
+                if (
+                    top.value == "django"
+                    and middle.value == "utils"
+                    and last.value == "encoding"
+                ):
+                    new_names = []
+                    new_import_missing = True
+                    new_import_alias = None
+                    for import_alias in original_node.names:
+                        if import_alias.evaluated_name == "force_text":
+                            new_import_alias = ImportAlias(name=Name("force_str"))
+                        else:
+                            if import_alias.evaluated_name == "force_str":
+                                new_import_missing = False
+                            new_names.append(import_alias)
+                    if new_import_missing and new_import_alias is not None:
+                        new_names.append(new_import_alias)
+                    new_names = list(sorted(new_names, key=lambda n: n.evaluated_name))
+                    return ImportFrom(module=updated_node.module, names=new_names)
         return super().leave_ImportFrom(original_node, updated_node)
 
     def leave_Call(self, original_node: Call, updated_node: Call) -> BaseExpression:

--- a/tests/codemods/test_django_40.py
+++ b/tests/codemods/test_django_40.py
@@ -10,9 +10,15 @@ class TestForceTextToStrCommand(CodemodTest):
     def test_noop(self) -> None:
         """Test when nothing should change."""
         before = """
+            from django import conf
+            from django.utils import encoding
+
             foo = force_str("bar")
         """
         after = """
+            from django import conf
+            from django.utils import encoding
+
             foo = force_str("bar")
         """
 


### PR DESCRIPTION
If a file has other kind of imports, the codemad crashes with:

```
ValueError: not enough values to unpack (expected 3, got 0)
```