### PR TITLE
Rename commands to reflect the functions they work with

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,10 @@ to add more for helping with upcoming deprecations.
 
 Currently implemented:
 
-* ``django_codemod.commands.django_40.ForceTextToStrCommand``: migrate deprecated
+* ``django_codemod.commands.django_40.ForceTextToForceStrCommand``: migrate deprecated
   ``force_str()`` function to ``force_str()``.
 
-* ``django_codemod.commands.django_40.SmartTextToStrCommand``: migrate deprecated
+* ``django_codemod.commands.django_40.SmartTextToForceStrCommand``: migrate deprecated
   ``smart_str()`` function to ``smart_str()``.
 
 * ``django_codemod.commands.django_40.UGetTextToGetTextCommand``: migrate deprecated

--- a/django_codemod/commands/django_40.py
+++ b/django_codemod/commands/django_40.py
@@ -43,7 +43,7 @@ class BaseFuncRename(VisitorBasedCodemodCommand, ABC):
         return super().leave_Call(original_node, updated_node)
 
 
-class ForceTextToStrCommand(BaseFuncRename):
+class ForceTextToForceStrCommand(BaseFuncRename):
     """Help resolve deprecation of django.utils.encoding.force_text."""
 
     DESCRIPTION: str = "Replaces force_text() by force_str()."
@@ -64,7 +64,7 @@ class ForceTextToStrCommand(BaseFuncRename):
         )
 
 
-class SmartTextToStrCommand(ForceTextToStrCommand):
+class SmartTextToForceStrCommand(ForceTextToForceStrCommand):
     """Help resolve deprecation of django.utils.encoding.smart_text."""
 
     DESCRIPTION: str = "Replaces smart_text() by smart_str()."

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ Should work nicely with [libCST codemods](https://libcst.readthedocs.io/en/lates
 3. Run libCST with the command from `django-codemod` that you want to apply:
 
    ```bash
-   python3 -m libcst.tool codemod django_40.ForceTextToStrCommand .
+   python3 -m libcst.tool codemod django_40.ForceTextToForceStrCommand .
    ```
 
    This will apply to code modifications for all the code under `.` **in place**.

--- a/tests/commands/test_django_40.py
+++ b/tests/commands/test_django_40.py
@@ -1,15 +1,15 @@
 from libcst.codemod import CodemodTest
 
 from django_codemod.commands.django_40 import (
-    ForceTextToStrCommand,
-    SmartTextToStrCommand,
+    ForceTextToForceStrCommand,
+    SmartTextToForceStrCommand,
     UGetTextToGetTextCommand,
 )
 
 
-class TestForceTextToStrCommand(CodemodTest):
+class TestForceTextToForceStrCommand(CodemodTest):
 
-    TRANSFORM = ForceTextToStrCommand
+    TRANSFORM = ForceTextToForceStrCommand
 
     def test_noop(self) -> None:
         """Test when nothing should change."""
@@ -77,9 +77,9 @@ class TestForceTextToStrCommand(CodemodTest):
         self.assertCodemod(before, after)
 
 
-class TestSmartTextToStrCommand(CodemodTest):
+class TestSmartTextToForceStrCommand(CodemodTest):
 
-    TRANSFORM = SmartTextToStrCommand
+    TRANSFORM = SmartTextToForceStrCommand
 
     def test_noop(self) -> None:
         """Test when nothing should change."""


### PR DESCRIPTION
Rename `ForceTextToStrCommand` to `ForceTextToForceStrCommand` and `SmartTextToStrCommand` to `SmartTextToSmartStrCommand`.