### PR TITLE
Migrate package metadata to declarative syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,43 @@
+[metadata]
+name = django-codemod
+version = attr: django_codemod.__version__
+author = Bruno Alla
+author_email = alla.brunoo@gmail.com
+description = Collections of libCST codemodders to upgrade Django
+license = MIT license
+license_file = LICENSE
+long_description = file:README.rst
+keywords = django, codemod, libCST
+url = https://django-codemod.readthedocs.io
+project_urls =
+    Source = https://github.com/browniebroke/django-codemod
+    Documentation = https://django-codemod.readthedocs.io
+    Travis CI = https://travis-ci.com/browniebroke/django-codemod
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Natural Language :: English
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.6
+packages = find:
+include_package_data = true
+zip_safe = false
+install_requires =
+    libcst
+test_require =
+    pytest>=3
+
+[options.packages.find]
+include =
+    django_codemod
+    django_codemod.*
+
 [bumpversion]
 current_version = 0.2.0
 commit = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,6 @@ current_version = 0.2.0
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:django_codemod/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,4 @@
 #!/usr/bin/env python
+from setuptools import setup
 
-"""The setup script."""
-
-from setuptools import setup, find_packages
-
-with open("README.rst") as readme_file:
-    readme = readme_file.read()
-
-requirements = ["libcst"]
-
-setup_requirements = ["pytest-runner"]
-
-test_requirements = ["pytest>=3"]
-
-setup(
-    author="Bruno Alla",
-    author_email="alla.brunoo@gmail.com",
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-    ],
-    description="Codemod to help upgrading to newer versions of Django",
-    install_requires=requirements,
-    license="MIT license",
-    long_description=readme,
-    include_package_data=True,
-    keywords="django,codemod",
-    name="django-codemod",
-    packages=find_packages(include=["django_codemod", "django_codemod.*"]),
-    setup_requires=setup_requirements,
-    test_suite="tests",
-    tests_require=test_requirements,
-    url="https://github.com/browniebroke/django-codemod",
-    version="0.2.0",
-    zip_safe=False,
-)
+setup()


### PR DESCRIPTION
Move metadata from `setup.py` to `setup.cfg` as per [this documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files).