### PR TITLE
Refactor BaseSimpleFuncRename to simplify implementing new codemod

### DIFF
--- a/django_codemod/commands/base.py
+++ b/django_codemod/commands/base.py
@@ -1,7 +1,7 @@
 """Module to implement base functionality."""
 
 from abc import ABC
-from typing import Union
+from typing import Union, Sequence
 
 from libcst import (
     matchers as m,
@@ -10,6 +10,7 @@ from libcst import (
     BaseExpression,
     Name,
     RemoveFromParent,
+    Arg,
 )
 from libcst._nodes.statement import ImportFrom, BaseSmallStatement
 from libcst.codemod import VisitorBasedCodemodCommand
@@ -75,5 +76,9 @@ class BaseSimpleFuncRename(VisitorBasedCodemodCommand, ABC):
 
     def leave_Call(self, original_node: Call, updated_node: Call) -> BaseExpression:
         if m.matches(updated_node, m.Call(func=m.Name(self.old_name))):
-            return Call(args=updated_node.args, func=Name(self.new_name))
+            updated_args = self.update_call_args(updated_node)
+            return Call(args=updated_args, func=Name(self.new_name))
         return super().leave_Call(original_node, updated_node)
+
+    def update_call_args(self, node: Call) -> Sequence[Arg]:
+        return node.args

--- a/django_codemod/commands/django_30.py
+++ b/django_codemod/commands/django_30.py
@@ -4,8 +4,10 @@ Module to fix things removed in Django 3.0.
 This is expected to cover most of the things listed in this section:
 https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-3-0
 """
-from libcst import ImportFrom, Call, BaseExpression, Name, Arg
-from libcst import matchers as m
+from typing import Sequence
+
+from libcst import Call, Name, Arg
+
 from django_codemod.commands.base import BaseSimpleFuncRename
 
 
@@ -13,22 +15,8 @@ class RenderToResponseToRenderCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.shortcuts.render_to_response."""
 
     DESCRIPTION: str = "Replaces render_to_response() by render()."
-    old_name = "render_to_response"
-    new_name = "render"
+    rename_from = "django.shortcuts.render_to_response"
+    rename_to = "django.shortcuts.render"
 
-    def _test_import_from(self, node: ImportFrom) -> bool:
-        return m.matches(
-            node,
-            m.ImportFrom(
-                module=m.Attribute(value=m.Name("django"), attr=m.Name("shortcuts")),
-            ),
-        )
-
-    def leave_Call(self, original_node: Call, updated_node: Call) -> BaseExpression:
-        if m.matches(updated_node, m.Call(func=m.Name(self.old_name))):
-            updated_args = (
-                Arg(value=Name("None")),
-                *updated_node.args,
-            )
-            return Call(args=updated_args, func=Name(self.new_name))
-        return super().leave_Call(original_node, updated_node)
+    def update_call_args(self, node: Call) -> Sequence[Arg]:
+        return (Arg(value=Name("None")), *node.args)

--- a/django_codemod/commands/django_40.py
+++ b/django_codemod/commands/django_40.py
@@ -25,82 +25,56 @@ class ForceTextToForceStrCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.encoding.force_text."""
 
     DESCRIPTION: str = "Replaces force_text() by force_str()."
-    old_name = "force_text"
-    new_name = "force_str"
-
-    def _test_import_from(self, node: ImportFrom) -> bool:
-        return m.matches(
-            node,
-            m.ImportFrom(
-                module=m.Attribute(
-                    value=m.Attribute(
-                        value=m.Name("django"), attr=m.Name(value="utils")
-                    ),
-                    attr=m.Name("encoding"),
-                ),
-            ),
-        )
+    rename_from = "django.utils.encoding.force_text"
+    rename_to = "django.utils.encoding.force_str"
 
 
-class SmartTextToForceStrCommand(ForceTextToForceStrCommand):
+class SmartTextToForceStrCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.encoding.smart_text."""
 
     DESCRIPTION: str = "Replaces smart_text() by smart_str()."
-    old_name = "smart_text"
-    new_name = "smart_str"
+    rename_from = "django.utils.encoding.smart_text"
+    rename_to = "django.utils.encoding.smart_str"
 
 
 class UGetTextToGetTextCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.translation.ugettext."""
 
     DESCRIPTION: str = "Replaces ugettext() by gettext()."
-    old_name = "ugettext"
-    new_name = "gettext"
-
-    def _test_import_from(self, node: ImportFrom) -> bool:
-        return m.matches(
-            node,
-            m.ImportFrom(
-                module=m.Attribute(
-                    value=m.Attribute(
-                        value=m.Name("django"), attr=m.Name(value="utils")
-                    ),
-                    attr=m.Name("translation"),
-                ),
-            ),
-        )
+    rename_from = "django.utils.translation.ugettext"
+    rename_to = "django.utils.translation.gettext"
 
 
-class UGetTextLazyToGetTextLazyCommand(UGetTextToGetTextCommand):
+class UGetTextLazyToGetTextLazyCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.translation.ugettext_lazy."""
 
     DESCRIPTION: str = "Replaces ugettext_lazy() by gettext_lazy()."
-    old_name = "ugettext_lazy"
-    new_name = "gettext_lazy"
+    rename_from = "django.utils.translation.ugettext_lazy"
+    rename_to = "django.utils.translation.gettext_lazy"
 
 
-class UGetTextNoopToGetTextNoopCommand(UGetTextToGetTextCommand):
+class UGetTextNoopToGetTextNoopCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.translation.ugettext_noop."""
 
     DESCRIPTION: str = "Replaces ugettext_noop() by gettext_noop()."
-    old_name = "ugettext_noop"
-    new_name = "gettext_noop"
+    rename_from = "django.utils.translation.ugettext_noop"
+    rename_to = "django.utils.translation.gettext_noop"
 
 
-class UNGetTextToNGetTextCommand(UGetTextToGetTextCommand):
+class UNGetTextToNGetTextCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.translation.ungettext."""
 
     DESCRIPTION: str = "Replaces ungettext() by ngettext()."
-    old_name = "ungettext"
-    new_name = "ngettext"
+    rename_from = "django.utils.translation.ungettext"
+    rename_to = "django.utils.translation.ngettext"
 
 
-class UNGetTextLazyToNGetTextLazyCommand(UGetTextToGetTextCommand):
+class UNGetTextLazyToNGetTextLazyCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.utils.translation.ungettext_lazy."""
 
     DESCRIPTION: str = "Replaces ungettext_lazy() by ngettext_lazy()."
-    old_name = "ungettext_lazy"
-    new_name = "ngettext_lazy"
+    rename_from = "django.utils.translation.ungettext_lazy"
+    rename_to = "django.utils.translation.ngettext_lazy"
 
 
 class URLToRePathCommand(VisitorBasedCodemodCommand):

--- a/django_codemod/commands/django_40.py
+++ b/django_codemod/commands/django_40.py
@@ -4,20 +4,6 @@ Module to fix things removed in Django 4.0.
 This is expected to cover most of the things listed in this section:
 https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0
 """
-from typing import Union
-
-from libcst import (
-    matchers as m,
-    RemovalSentinel,
-    Call,
-    BaseExpression,
-    Name,
-    RemoveFromParent,
-)
-from libcst._nodes.statement import ImportFrom, BaseSmallStatement
-from libcst.codemod import VisitorBasedCodemodCommand
-from libcst.codemod.visitors import AddImportsVisitor
-
 from django_codemod.commands.base import BaseSimpleFuncRename
 
 
@@ -77,49 +63,9 @@ class UNGetTextLazyToNGetTextLazyCommand(BaseSimpleFuncRename):
     rename_to = "django.utils.translation.ngettext_lazy"
 
 
-class URLToRePathCommand(VisitorBasedCodemodCommand):
+class URLToRePathCommand(BaseSimpleFuncRename):
     """Resolve deprecation of django.conf.urls.url."""
 
     DESCRIPTION: str = "Replaces url() by re_path()."
-
-    def _test_import_from(self, node: ImportFrom) -> bool:
-        return m.matches(
-            node,
-            m.ImportFrom(
-                module=m.Attribute(
-                    value=m.Attribute(
-                        value=m.Name("django"), attr=m.Name(value="conf")
-                    ),
-                    attr=m.Name("urls"),
-                ),
-            ),
-        )
-
-    def leave_ImportFrom(
-        self, original_node: ImportFrom, updated_node: ImportFrom
-    ) -> Union[BaseSmallStatement, RemovalSentinel]:
-        if self._test_import_from(updated_node):
-            new_names = []
-            new_import_missing = True
-            new_import_alias = None
-            for import_alias in original_node.names:
-                if import_alias.evaluated_name == "url":
-                    AddImportsVisitor.add_needed_import(
-                        self.context, "django.urls", "re_path",
-                    )
-                else:
-                    if import_alias.evaluated_name == "re_path":
-                        new_import_missing = False
-                    new_names.append(import_alias)
-            if new_import_missing and new_import_alias is not None:
-                new_names.append(new_import_alias)
-            if not new_names:
-                return RemoveFromParent()
-            new_names = list(sorted(new_names, key=lambda n: n.evaluated_name))
-            return ImportFrom(module=updated_node.module, names=new_names)
-        return super().leave_ImportFrom(original_node, updated_node)
-
-    def leave_Call(self, original_node: Call, updated_node: Call) -> BaseExpression:
-        if m.matches(updated_node, m.Call(func=m.Name("url"))):
-            return Call(args=updated_node.args, func=Name("re_path"))
-        return super().leave_Call(original_node, updated_node)
+    rename_from = "django.conf.urls.url"
+    rename_to = "django.urls.re_path"


### PR DESCRIPTION
- Replace `old_name` and `new_name` by `rename_from` and `rename_to` with full import path
- Generate the import from matcher based on the `rename_from` attribute
- Replace custom logic to insert new import by `AddImportsVisitor`
- Hook to easily update `Call` arguments