### PR TITLE
Fix bug with lost alias when 'import as' is used

### DIFF
--- a/django_codemod/visitors/base.py
+++ b/django_codemod/visitors/base.py
@@ -63,8 +63,14 @@ class BaseSimpleFuncRenameTransformer(ContextAwareTransformer, ABC):
             new_names = []
             for import_alias in original_node.names:
                 if import_alias.evaluated_name == self.old_name:
+                    as_name = (
+                        import_alias.asname.name.value if import_alias.asname else None
+                    )
                     AddImportsVisitor.add_needed_import(
-                        self.context, ".".join(self.new_module_parts), self.new_name,
+                        context=self.context,
+                        module=".".join(self.new_module_parts),
+                        obj=self.new_name,
+                        asname=as_name,
                     )
                 else:
                     new_names.append(import_alias)

--- a/tests/commands/test_django_40.py
+++ b/tests/commands/test_django_40.py
@@ -168,6 +168,20 @@ class TestUGetTextToGetTextCommand(CodemodTest):
         """
         self.assertCodemod(before, after)
 
+    def test_import_with_alias(self) -> None:
+        """Check case with a common alias."""
+        before = """
+            from django.utils.translation import ugettext as _
+
+            result = _(content)
+        """
+        after = """
+            from django.utils.translation import gettext as _
+
+            result = _(content)
+        """
+        self.assertCodemod(before, after)
+
     def test_already_imported_substitution(self) -> None:
         """Test case where gettext is already in the imports."""
         before = """
@@ -365,6 +379,20 @@ class TestUNGetTextLazyToNGetTextLazyCommand(CodemodTest):
             from django.utils.translation import ngettext_lazy
 
             result = ngettext_lazy(content, plural_content, count)
+        """
+        self.assertCodemod(before, after)
+
+    def test_import_as_alias(self) -> None:
+        """Check with a common import alias."""
+        before = """
+            from django.utils.translation import ungettext_lazy as _
+
+            result = _(content, plural_content, count)
+        """
+        after = """
+            from django.utils.translation import ngettext_lazy as _
+
+            result = _(content, plural_content, count)
         """
         self.assertCodemod(before, after)
 


### PR DESCRIPTION
It's quite common to import ugettext as `_` like this:

```
from django.utils.translation import ugettext as _

translated = = _("content")
```

In such case, the `_` alis is lost which causes invalid syntax.