### PR TITLE
Add the `obj` argument to `InlineModelAdmin.has_add_permission()`

### DIFF
--- a/django_codemod/commands/django_codemod.py
+++ b/django_codemod/commands/django_codemod.py
@@ -1,5 +1,8 @@
 from .base import BaseCodemodCommand
-from ..visitors.django_30 import RenderToResponseToRenderTransformer
+from ..visitors.django_30 import (
+    RenderToResponseToRenderTransformer,
+    InlineHasAddPermissionsTransformer,
+)
 from ..visitors.django_40 import (
     ForceTextToForceStrTransformer,
     SmartTextToForceStrTransformer,
@@ -14,24 +17,23 @@ from ..visitors.django_40 import (
 
 class Django30Command(BaseCodemodCommand):
     """
-    Resolve deprecations for removals in Django 3.0.
+    Resolve following deprecations:
 
-    Combines all the other commands in this module, to fix these deprecations:
-
-    - ``django.shortcuts.render_to_response``
+    - Replaces ``render_to_response()`` by ``render()`` and add ``request=None``
+      as the first argument of ``render()``.
+    - Add the ``obj`` argument to ``InlineModelAdmin.has_add_permission()``.
     """
 
     DESCRIPTION: str = "Resolve deprecations for removals in Django 3.0."
     transformers = [
         RenderToResponseToRenderTransformer,
+        InlineHasAddPermissionsTransformer,
     ]
 
 
 class Django40Command(BaseCodemodCommand):
     """
-    Resolve deprecations for removals in Django 4.0.
-
-    Combines all the other commands in this module, to fix these deprecations:
+    Resolve following deprecations:
 
     - ``django.utils.encoding.force_text``
     - ``django.utils.encoding.smart_text``

--- a/django_codemod/visitors/django_30.py
+++ b/django_codemod/visitors/django_30.py
@@ -1,8 +1,19 @@
 # This is expected to cover most of the things listed in this section:
 # https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-3-0
-from typing import Sequence
+from typing import Sequence, Union
 
-from libcst import Call, Name, Arg
+from libcst import (
+    Call,
+    Name,
+    Arg,
+    RemovalSentinel,
+    matchers as m,
+    ClassDef,
+    BaseStatement,
+    FunctionDef,
+    Param,
+)
+from libcst.codemod import ContextAwareTransformer
 
 from .base import BaseSimpleFuncRenameTransformer
 
@@ -20,3 +31,62 @@ class RenderToResponseToRenderTransformer(BaseSimpleFuncRenameTransformer):
 
     def update_call_args(self, node: Call) -> Sequence[Arg]:
         return (Arg(value=Name("None")), *node.args)
+
+
+class InlineHasAddPermissionsTransformer(ContextAwareTransformer):
+    """Add the ``obj`` argument to ``InlineModelAdmin.has_add_permission()``."""
+
+    context_key = "InlineHasAddPermissionsTransformer"
+
+    def visit_ClassDef_bases(self, node: ClassDef) -> None:
+        if m.matches(
+            node,
+            m.ClassDef(
+                bases=(
+                    m.OneOf(
+                        m.Arg(
+                            m.Attribute(
+                                value=m.Name("admin"), attr=m.Name("TabularInline")
+                            )
+                        ),
+                        m.Arg(m.Name("TabularInline")),
+                        m.Arg(
+                            m.Attribute(
+                                value=m.Name("admin"), attr=m.Name("StackedInline")
+                            )
+                        ),
+                        m.Arg(m.Name("StackedInline")),
+                    ),
+                )
+            ),
+        ):
+            self.context.scratch[self.context_key] = True
+        super().visit_ClassDef_bases(node)
+
+    def leave_ClassDef(
+        self, original_node: ClassDef, updated_node: ClassDef
+    ) -> Union[BaseStatement, RemovalSentinel]:
+        self.context.scratch.pop(self.context_key, None)
+        return super().leave_ClassDef(original_node, updated_node)
+
+    @property
+    def _is_context_right(self):
+        return self.context.scratch.get(self.context_key, False)
+
+    def leave_FunctionDef(
+        self, original_node: FunctionDef, updated_node: FunctionDef
+    ) -> Union[BaseStatement, RemovalSentinel]:
+        if (
+            m.matches(updated_node, m.FunctionDef(name=m.Name("has_add_permission")))
+            and self._is_context_right
+        ):
+            if len(updated_node.params.params) == 2:
+                old_params = updated_node.params
+                updated_params = old_params.with_changes(
+                    params=(
+                        *old_params.params,
+                        Param(name=Name("obj"), default=Name("None")),
+                    )
+                )
+                return updated_node.with_changes(params=updated_params)
+        return super().leave_FunctionDef(original_node, updated_node)

--- a/docs/codemods.rst
+++ b/docs/codemods.rst
@@ -26,7 +26,7 @@ This command should fix things `removed in Django 3.0`_.
 Django 4.0
 ----------
 
-These command should fix things `removed in Django 4.0`_.
+This command should fix things `removed in Django 4.0`_.
 
 .. _removed in Django 4.0: https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0
 


### PR DESCRIPTION
From [Django 3.0 deprecations](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-3-0):

> The shim to allow InlineModelAdmin.has_add_permission() to be defined without an obj argument will be removed.