### PR TITLE
Move duplicated visitors tests for base class

### DIFF
--- a/tests/visitors/test_base.py
+++ b/tests/visitors/test_base.py
@@ -1,0 +1,140 @@
+from django_codemod.visitors.base import BaseSimpleFuncRenameTransformer
+
+from .base import BaseVisitorTest
+
+
+class SameModuleRenameTransformer(BaseSimpleFuncRenameTransformer):
+    """Simple transformer renaming function from same module."""
+
+    rename_from = "django.dummy.module.func"
+    rename_to = "django.dummy.module.better_func"
+
+
+class TestSimpleFuncRenameTransformer(BaseVisitorTest):
+
+    transformer = SameModuleRenameTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.dummy.module import func
+
+            result = func()
+        """
+        after = """
+            from django.dummy.module import better_func
+
+            result = better_func()
+        """
+        self.assertCodemod(before, after)
+
+    def test_already_imported(self) -> None:
+        before = """
+            from django.dummy.module import func, better_func
+
+            result = func(content)
+        """
+        after = """
+            from django.dummy.module import better_func
+
+            result = better_func(content)
+        """
+        self.assertCodemod(before, after)
+
+    def test_import_with_alias(self) -> None:
+        before = """
+            from django.dummy.module import func as aliased_func
+
+            result = aliased_func()
+        """
+        after = """
+            from django.dummy.module import better_func as aliased_func
+
+            result = aliased_func()
+        """
+        self.assertCodemod(before, after)
+
+    def test_extra_trailing_comma_when_last(self) -> None:
+        """Extra trailing comma when removed import is the last one."""
+        before = """
+            from django.dummy.module import better_func, func
+
+            result = func(content)
+        """
+        after = """
+            from django.dummy.module import better_func
+
+            result = better_func(content)
+        """
+        self.assertCodemod(before, after)
+
+    def test_parse_call_no_value(self) -> None:
+        """Bug with function call without name."""
+        before = """
+            factory()()
+        """
+        after = """
+            factory()()
+        """
+        self.assertCodemod(before, after)
+
+    def test_lambda_no_value(self) -> None:
+        """Bug with lambda call without name."""
+        before = """
+            (lambda x: x)(something)
+        """
+        after = """
+            (lambda x: x)(something)
+        """
+        self.assertCodemod(before, after)
+
+
+class OtherModuleRenameTransformer(BaseSimpleFuncRenameTransformer):
+    """Transformer with different module."""
+
+    rename_from = "django.dummy.module.func"
+    rename_to = "django.better.dummy.better_func"
+
+
+class TestOtherModuleRenameTransformer(BaseVisitorTest):
+
+    transformer = OtherModuleRenameTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.dummy.module import func
+
+            result = func()
+        """
+        after = """
+            from django.better.dummy import better_func
+
+            result = better_func()
+        """
+        self.assertCodemod(before, after)
+
+    def test_already_imported(self) -> None:
+        before = """
+            from django.dummy.module import func
+            from django.better.dummy import better_func
+
+            result = func(content)
+        """
+        after = """
+            from django.better.dummy import better_func
+
+            result = better_func(content)
+        """
+        self.assertCodemod(before, after)
+
+    def test_import_with_alias(self) -> None:
+        before = """
+            from django.dummy.module import func as aliased_func
+
+            result = aliased_func()
+        """
+        after = """
+            from django.better.dummy import better_func as aliased_func
+
+            result = aliased_func()
+        """
+        self.assertCodemod(before, after)

--- a/tests/visitors/test_django_30.py
+++ b/tests/visitors/test_django_30.py
@@ -12,21 +12,6 @@ class TestRenderToResponseToRenderTransformer(BaseVisitorTest):
 
     transformer = RenderToResponseToRenderTransformer
 
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django.shortcuts import get_object_or_404, render
-
-            result = render(request, "index.html", context={})
-        """
-        after = """
-            from django.shortcuts import get_object_or_404, render
-
-            result = render(request, "index.html", context={})
-        """
-
-        self.assertCodemod(before, after)
-
     def test_simple_substitution(self) -> None:
         """Check simple use case."""
         before = """
@@ -38,20 +23,6 @@ class TestRenderToResponseToRenderTransformer(BaseVisitorTest):
             from django.shortcuts import render
 
             result = render(None, "index.html", context={}, status=None)
-        """
-        self.assertCodemod(before, after)
-
-    def test_already_imported_substitution(self) -> None:
-        """Test case where render is already in the imports."""
-        before = """
-            from django.shortcuts import get_object_or_404, render_to_response, render
-
-            result = render_to_response("index.html", context={})
-        """
-        after = """
-            from django.shortcuts import get_object_or_404, render
-
-            result = render(None, "index.html", context={})
         """
         self.assertCodemod(before, after)
 

--- a/tests/visitors/test_django_40.py
+++ b/tests/visitors/test_django_40.py
@@ -16,75 +16,9 @@ class TestForceTextToForceStrTransformer(BaseVisitorTest):
 
     transformer = ForceTextToForceStrTransformer
 
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django import conf
-            from django.utils import encoding
-
-            foo = force_str("bar")
-        """
-        after = """
-            from django import conf
-            from django.utils import encoding
-
-            foo = force_str("bar")
-        """
-
-        self.assertCodemod(before, after)
-
     def test_simple_substitution(self) -> None:
-        """Check simple use case."""
         before = """
             from django.utils.encoding import force_text
-
-            result = force_text(content)
-        """
-        after = """
-            from django.utils.encoding import force_str
-
-            result = force_str(content)
-        """
-        self.assertCodemod(before, after)
-
-    def test_already_imported_substitution(self) -> None:
-        """Test case where force_str is already in the imports."""
-        before = """
-            from django.utils.encoding import force_text, force_str
-
-            result = force_text(content)
-        """
-        after = """
-            from django.utils.encoding import force_str
-
-            result = force_str(content)
-        """
-        self.assertCodemod(before, after)
-
-    def test_call_no_value(self) -> None:
-        """Regression test for function call without name."""
-        before = """
-            factory()()
-        """
-        after = """
-            factory()()
-        """
-        self.assertCodemod(before, after)
-
-    def test_lambda_no_value(self) -> None:
-        """Regression test for lambda call without name."""
-        before = """
-            (lambda x: x)(something)
-        """
-        after = """
-            (lambda x: x)(something)
-        """
-        self.assertCodemod(before, after)
-
-    def test_extra_trailing_comma_when_last(self) -> None:
-        """Extra trailing comma when removed import is the last one."""
-        before = """
-            from django.utils.encoding import force_str, force_text
 
             result = force_text(content)
         """
@@ -100,23 +34,6 @@ class TestSmartTextToForceStrTransformer(BaseVisitorTest):
 
     transformer = SmartTextToForceStrTransformer
 
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django import conf
-            from django.utils import encoding
-
-            foo = smart_str("bar")
-        """
-        after = """
-            from django import conf
-            from django.utils import encoding
-
-            foo = smart_str("bar")
-        """
-
-        self.assertCodemod(before, after)
-
     def test_simple_substitution(self) -> None:
         """Check simple use case."""
         before = """
@@ -131,41 +48,10 @@ class TestSmartTextToForceStrTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
-    def test_already_imported_substitution(self) -> None:
-        """Test case where smart_str is already in the imports."""
-        before = """
-            from django.utils.encoding import smart_text, smart_str
-
-            result = smart_text(content)
-        """
-        after = """
-            from django.utils.encoding import smart_str
-
-            result = smart_str(content)
-        """
-        self.assertCodemod(before, after)
-
 
 class TestUGetTextToGetTextTransformer(BaseVisitorTest):
 
     transformer = UGetTextToGetTextTransformer
-
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django import conf
-            from django.utils import translation
-
-            foo = gettext("bar")
-        """
-        after = """
-            from django import conf
-            from django.utils import translation
-
-            foo = gettext("bar")
-        """
-
-        self.assertCodemod(before, after)
 
     def test_simple_substitution(self) -> None:
         """Check simple use case."""
@@ -214,41 +100,10 @@ class TestUGetTextLazyToGetTextLazyTransformer(BaseVisitorTest):
 
     transformer = UGetTextLazyToGetTextLazyTransformer
 
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django import conf
-            from django.utils import translation
-
-            foo = gettext_lazy("bar")
-        """
-        after = """
-            from django import conf
-            from django.utils import translation
-
-            foo = gettext_lazy("bar")
-        """
-
-        self.assertCodemod(before, after)
-
     def test_simple_substitution(self) -> None:
         """Check simple use case."""
         before = """
             from django.utils.translation import ugettext_lazy
-
-            result = ugettext_lazy(content)
-        """
-        after = """
-            from django.utils.translation import gettext_lazy
-
-            result = gettext_lazy(content)
-        """
-        self.assertCodemod(before, after)
-
-    def test_already_imported_substitution(self) -> None:
-        """Test case where gettext_lazy is already in the imports."""
-        before = """
-            from django.utils.translation import ugettext_lazy, gettext_lazy
 
             result = ugettext_lazy(content)
         """
@@ -295,41 +150,10 @@ class TestUGetTextNoopToGetTextNoopTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
-    def test_already_imported_substitution(self) -> None:
-        """Test case where gettext_noop is already in the imports."""
-        before = """
-            from django.utils.translation import ugettext_noop, gettext_noop
-
-            result = ugettext_noop(content)
-        """
-        after = """
-            from django.utils.translation import gettext_noop
-
-            result = gettext_noop(content)
-        """
-        self.assertCodemod(before, after)
-
 
 class TestUNGetTextToNGetTextTransformer(BaseVisitorTest):
 
     transformer = UNGetTextToNGetTextTransformer
-
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django import conf
-            from django.utils import translation
-
-            foo = ngettext("bar", "bars", count)
-        """
-        after = """
-            from django import conf
-            from django.utils import translation
-
-            foo = ngettext("bar", "bars", count)
-        """
-
-        self.assertCodemod(before, after)
 
     def test_simple_substitution(self) -> None:
         """Check simple use case."""
@@ -345,41 +169,10 @@ class TestUNGetTextToNGetTextTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
-    def test_already_imported_substitution(self) -> None:
-        """Test case where ngettext is already in the imports."""
-        before = """
-            from django.utils.translation import ungettext, ngettext
-
-            result = ungettext(content, plural_content, count)
-        """
-        after = """
-            from django.utils.translation import ngettext
-
-            result = ngettext(content, plural_content, count)
-        """
-        self.assertCodemod(before, after)
-
 
 class TestUNGetTextLazyToNGetTextLazyTransformer(BaseVisitorTest):
 
     transformer = UNGetTextLazyToNGetTextLazyTransformer
-
-    def test_noop(self) -> None:
-        """Test when nothing should change."""
-        before = """
-            from django import conf
-            from django.utils import translation
-
-            foo = ngettext_lazy("bar", "bars", count)
-        """
-        after = """
-            from django import conf
-            from django.utils import translation
-
-            foo = ngettext_lazy("bar", "bars", count)
-        """
-
-        self.assertCodemod(before, after)
 
     def test_simple_substitution(self) -> None:
         """Check simple use case."""
@@ -406,20 +199,6 @@ class TestUNGetTextLazyToNGetTextLazyTransformer(BaseVisitorTest):
             from django.utils.translation import ngettext_lazy as _
 
             result = _(content, plural_content, count)
-        """
-        self.assertCodemod(before, after)
-
-    def test_already_imported_substitution(self) -> None:
-        """Test case where ngettext_lazy is already in the imports."""
-        before = """
-            from django.utils.translation import ungettext_lazy, ngettext_lazy
-
-            result = ungettext_lazy(content, plural_content, count)
-        """
-        after = """
-            from django.utils.translation import ngettext_lazy
-
-            result = ngettext_lazy(content, plural_content, count)
         """
         self.assertCodemod(before, after)
 
@@ -462,27 +241,6 @@ class TestURLToRePathTransformer(BaseVisitorTest):
         """
         after = """
             from django.urls import re_path, include
-
-            urlpatterns = [
-                re_path(r'^index/$', views.index, name='index'),
-                re_path(r'^weblog/', include('blog.urls')),
-            ]
-        """
-        self.assertCodemod(before, after)
-
-    def test_already_imported_substitution(self) -> None:
-        """Test case where re_path is already in the imports."""
-        before = """
-            from django.urls import include, re_path
-            from django.conf.urls import url
-
-            urlpatterns = [
-                url(r'^index/$', views.index, name='index'),
-                re_path(r'^weblog/', include('blog.urls')),
-            ]
-        """
-        after = """
-            from django.urls import include, re_path
 
             urlpatterns = [
                 re_path(r'^index/$', views.index, name='index'),


### PR DESCRIPTION
Lots of the visitors tests actually are testing functionality from the base class, and they are duplicated all over.

This tests all the edge cases using the base class and reduce visitor tests to more minimal version.