### PR TITLE
Resolve deprecations from `django.utils.http` in Django 3.0

### DIFF
--- a/django_codemod/commands/django_codemod.py
+++ b/django_codemod/commands/django_codemod.py
@@ -3,6 +3,12 @@ from ..visitors.encoding import (
     ForceTextToForceStrTransformer,
     SmartTextToForceStrTransformer,
 )
+from ..visitors.http import (
+    HttpUrlQuotePlusTransformer,
+    HttpUrlQuoteTransformer,
+    HttpUrlUnQuotePlusTransformer,
+    HttpUrlUnQuoteTransformer,
+)
 from ..visitors.shortcuts import RenderToResponseToRenderTransformer
 from ..visitors.translations import (
     UGetTextLazyToGetTextLazyTransformer,
@@ -37,6 +43,10 @@ class Django40Command(BaseCodemodCommand):
 
     - ``django.utils.encoding.force_text``
     - ``django.utils.encoding.smart_text``
+    - ``django.utils.http.urlquote``
+    - ``django.utils.http.urlquote_plus``
+    - ``django.utils.http.urlunquote``
+    - ``django.utils.http.urlunquote_plus``
     - ``django.utils.translation.ugettext``
     - ``django.utils.translation.ugettext_lazy``
     - ``django.utils.translation.ugettext_noop``
@@ -48,6 +58,10 @@ class Django40Command(BaseCodemodCommand):
     DESCRIPTION: str = "Resolve deprecations of things removed in Django 4.0"
     transformers = [
         ForceTextToForceStrTransformer,
+        HttpUrlQuotePlusTransformer,
+        HttpUrlQuoteTransformer,
+        HttpUrlUnQuotePlusTransformer,
+        HttpUrlUnQuoteTransformer,
         SmartTextToForceStrTransformer,
         UGetTextLazyToGetTextLazyTransformer,
         UGetTextNoopToGetTextNoopTransformer,

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -1,5 +1,11 @@
 from .admin import InlineHasAddPermissionsTransformer
 from .encoding import ForceTextToForceStrTransformer, SmartTextToForceStrTransformer
+from .http import (
+    HttpUrlQuotePlusTransformer,
+    HttpUrlQuoteTransformer,
+    HttpUrlUnQuotePlusTransformer,
+    HttpUrlUnQuoteTransformer,
+)
 from .shortcuts import RenderToResponseToRenderTransformer
 from .translations import (
     UGetTextLazyToGetTextLazyTransformer,
@@ -12,6 +18,10 @@ from .urls import URLToRePathTransformer
 
 __all__ = (
     "ForceTextToForceStrTransformer",
+    "HttpUrlQuotePlusTransformer",
+    "HttpUrlQuoteTransformer",
+    "HttpUrlUnQuotePlusTransformer",
+    "HttpUrlUnQuoteTransformer",
     "InlineHasAddPermissionsTransformer",
     "RenderToResponseToRenderTransformer",
     "SmartTextToForceStrTransformer",

--- a/django_codemod/visitors/http.py
+++ b/django_codemod/visitors/http.py
@@ -1,0 +1,38 @@
+from django_codemod.constants import DJANGO_30, DJANGO_40
+from django_codemod.visitors.base import BaseSimpleFuncRenameTransformer
+
+
+class HttpUrlQuoteTransformer(BaseSimpleFuncRenameTransformer):
+    """Resolve deprecation of ``django.utils.http.urlquote``."""
+
+    deprecated_in = DJANGO_30
+    removed_in = DJANGO_40
+    rename_from = "django.utils.http.urlquote"
+    rename_to = "urllib.parse.quote"
+
+
+class HttpUrlQuotePlusTransformer(BaseSimpleFuncRenameTransformer):
+    """Resolve deprecation of ``django.utils.http.urlquote_plus``."""
+
+    deprecated_in = DJANGO_30
+    removed_in = DJANGO_40
+    rename_from = "django.utils.http.urlquote_plus"
+    rename_to = "urllib.parse.quote_plus"
+
+
+class HttpUrlUnQuoteTransformer(BaseSimpleFuncRenameTransformer):
+    """Resolve deprecation of ``django.utils.http.urlunquote``."""
+
+    deprecated_in = DJANGO_30
+    removed_in = DJANGO_40
+    rename_from = "django.utils.http.urlunquote"
+    rename_to = "urllib.parse.unquote"
+
+
+class HttpUrlUnQuotePlusTransformer(BaseSimpleFuncRenameTransformer):
+    """Resolve deprecation of ``django.utils.http.urlunquote_plus``."""
+
+    deprecated_in = DJANGO_30
+    removed_in = DJANGO_40
+    rename_from = "django.utils.http.urlunquote_plus"
+    rename_to = "urllib.parse.unquote_plus"

--- a/docs/codemods.rst
+++ b/docs/codemods.rst
@@ -21,5 +21,6 @@ Removed in Django 4.0
 Applied by passing the ``--removed-in 4.0`` or ``--deprecated-in 3.0`` option:
 
 - Replaces ``force_text`` and ``smart_text`` from the ``django.utils.encoding`` module by ``force_str`` and ``smart_str``
+- Replaces ``urlquote``, ``urlquote_plus``, ``urlunquote`` and ``urlunquote_plus`` from the ``django.utils.http`` module by their the functions they alias to, respectively ``quote``, ``quote_plus``, ``unquote`` and ``unquote_plus`` from the ``urllib.parse.quote`` module.
 - Replaces ``ugettext``, ``ugettext_lazy``, ``ugettext_noop``, ``ungettext``, and ``ungettext_lazy`` from the ``django.utils.translation`` module by their replacements, respectively ``gettext``, ``gettext_lazy``, ``gettext_noop``, ``ngettext``, and ``ngettext_lazy``.
 - Replaces ``django.conf.urls.url`` by ``django.urls.re_path``

--- a/tests/visitors/test_http.py
+++ b/tests/visitors/test_http.py
@@ -1,0 +1,79 @@
+from django_codemod.visitors import (
+    HttpUrlQuotePlusTransformer,
+    HttpUrlQuoteTransformer,
+    HttpUrlUnQuotePlusTransformer,
+    HttpUrlUnQuoteTransformer,
+)
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestHttpUrlQuoteTransformer(BaseVisitorTest):
+
+    transformer = HttpUrlQuoteTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.http import urlquote
+
+            result = urlquote(content)
+        """
+        after = """
+            from urllib.parse import quote
+
+            result = quote(content)
+        """
+        self.assertCodemod(before, after)
+
+
+class TestHttpUrlQuotePlusTransformer(BaseVisitorTest):
+
+    transformer = HttpUrlQuotePlusTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.http import urlquote_plus
+
+            result = urlquote_plus(content)
+        """
+        after = """
+            from urllib.parse import quote_plus
+
+            result = quote_plus(content)
+        """
+        self.assertCodemod(before, after)
+
+
+class TestHttpUrlUnQuoteTransformer(BaseVisitorTest):
+
+    transformer = HttpUrlUnQuoteTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.http import urlunquote
+
+            result = urlunquote(content)
+        """
+        after = """
+            from urllib.parse import unquote
+
+            result = unquote(content)
+        """
+        self.assertCodemod(before, after)
+
+
+class TestHttpUrlUnQuotePlusTransformer(BaseVisitorTest):
+
+    transformer = HttpUrlUnQuotePlusTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.http import urlunquote_plus
+
+            result = urlunquote_plus(content)
+        """
+        after = """
+            from urllib.parse import unquote_plus
+
+            result = unquote_plus(content)
+        """
+        self.assertCodemod(before, after)


### PR DESCRIPTION
From [Django 3.0 release notes](https://docs.djangoproject.com/en/dev/releases/3.0/#deprecated-features-3-0):

> `django.utils.http.urlquote()`, `urlquote_plus()`, `urlunquote()`, and `urlunquote_plus()` are deprecated in favor of the functions that they’re aliases for: `urllib.parse.quote()`, `quote_plus()`, `unquote()`, and `unquote_plus()`.