### PR TITLE
Resolve deprecation of `django.utils.text.unescape_entities` in Django 3.0

### DIFF
--- a/django_codemod/commands/django_codemod.py
+++ b/django_codemod/commands/django_codemod.py
@@ -3,6 +3,7 @@ from ..visitors.encoding import (
     ForceTextToForceStrTransformer,
     SmartTextToForceStrTransformer,
 )
+from ..visitors.html import UnescapeEntitiesTransformer
 from ..visitors.http import (
     HttpUrlQuotePlusTransformer,
     HttpUrlQuoteTransformer,
@@ -47,6 +48,7 @@ class Django40Command(BaseCodemodCommand):
     - ``django.utils.http.urlquote_plus``
     - ``django.utils.http.urlunquote``
     - ``django.utils.http.urlunquote_plus``
+    - ``django.utils.text.unescape_entities``
     - ``django.utils.translation.ugettext``
     - ``django.utils.translation.ugettext_lazy``
     - ``django.utils.translation.ugettext_noop``
@@ -69,4 +71,5 @@ class Django40Command(BaseCodemodCommand):
         UNGetTextLazyToNGetTextLazyTransformer,
         UNGetTextToNGetTextTransformer,
         URLToRePathTransformer,
+        UnescapeEntitiesTransformer,
     ]

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -1,5 +1,6 @@
 from .admin import InlineHasAddPermissionsTransformer
 from .encoding import ForceTextToForceStrTransformer, SmartTextToForceStrTransformer
+from .html import UnescapeEntitiesTransformer
 from .http import (
     HttpUrlQuotePlusTransformer,
     HttpUrlQuoteTransformer,
@@ -31,4 +32,5 @@ __all__ = (
     "UNGetTextLazyToNGetTextLazyTransformer",
     "UNGetTextToNGetTextTransformer",
     "URLToRePathTransformer",
+    "UnescapeEntitiesTransformer",
 )

--- a/django_codemod/visitors/html.py
+++ b/django_codemod/visitors/html.py
@@ -1,0 +1,11 @@
+from django_codemod.constants import DJANGO_30, DJANGO_40
+from django_codemod.visitors.base import BaseSimpleFuncRenameTransformer
+
+
+class UnescapeEntitiesTransformer(BaseSimpleFuncRenameTransformer):
+    """Resolve deprecation of ``django.utils.text.unescape_entities``."""
+
+    deprecated_in = DJANGO_30
+    removed_in = DJANGO_40
+    rename_from = "django.utils.text.unescape_entities"
+    rename_to = "html.unescape"

--- a/docs/codemods.rst
+++ b/docs/codemods.rst
@@ -23,4 +23,5 @@ Applied by passing the ``--removed-in 4.0`` or ``--deprecated-in 3.0`` option:
 - Replaces ``force_text`` and ``smart_text`` from the ``django.utils.encoding`` module by ``force_str`` and ``smart_str``
 - Replaces ``urlquote``, ``urlquote_plus``, ``urlunquote`` and ``urlunquote_plus`` from the ``django.utils.http`` module by their the functions they alias to, respectively ``quote``, ``quote_plus``, ``unquote`` and ``unquote_plus`` from the ``urllib.parse.quote`` module.
 - Replaces ``ugettext``, ``ugettext_lazy``, ``ugettext_noop``, ``ungettext``, and ``ungettext_lazy`` from the ``django.utils.translation`` module by their replacements, respectively ``gettext``, ``gettext_lazy``, ``gettext_noop``, ``ngettext``, and ``ngettext_lazy``.
+- Replaces ``unescape_entities`` from the ``django.utils.text`` module by ``html.unescape`` from the standard library.
 - Replaces ``django.conf.urls.url`` by ``django.urls.re_path``

--- a/tests/visitors/test_html.py
+++ b/tests/visitors/test_html.py
@@ -1,0 +1,20 @@
+from django_codemod.visitors import UnescapeEntitiesTransformer
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestUnescapeEntitiesTransformer(BaseVisitorTest):
+
+    transformer = UnescapeEntitiesTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.text import unescape_entities
+
+            result = unescape_entities(content)
+        """
+        after = """
+            from html import unescape
+
+            result = unescape(content)
+        """
+        self.assertCodemod(before, after)


### PR DESCRIPTION
From [Django 3.0 release notes](https://docs.djangoproject.com/en/dev/releases/3.0/#deprecated-features-3-0):

> `django.utils.text.unescape_entities()` is deprecated in favor of `html.unescape()`. Note that unlike `unescape_entities()`, `html.unescape()` evaluates lazy strings immediately.