### PR TITLE
Resolve deprecation of `django.utils.decorators.ContextDecorator` in Django 2.0

### DIFF
--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -1,4 +1,5 @@
 from .admin import InlineHasAddPermissionsTransformer
+from .decorators import ContextDecoratorTransformer
 from .encoding import (
     ForceTextTransformer,
     SmartTextTransformer,
@@ -26,6 +27,7 @@ from .urls import URLTransformer
 
 __all__ = (
     "AbsPathTransformer",
+    "ContextDecoratorTransformer",
     "ForceTextTransformer",
     "HttpUrlQuotePlusTransformer",
     "HttpUrlQuoteTransformer",

--- a/django_codemod/visitors/base.py
+++ b/django_codemod/visitors/base.py
@@ -28,8 +28,8 @@ def module_matcher(import_parts):
     return m.Attribute(value=value, attr=m.Name(attr))
 
 
-class BaseSimpleFuncRenameTransformer(ContextAwareTransformer, ABC):
-    """Base class to help rename or move a function."""
+class BaseSimpleRenameTransformer(ContextAwareTransformer, ABC):
+    """Base class to help rename or move a declaration."""
 
     rename_from: str
     rename_to: str
@@ -87,11 +87,15 @@ class BaseSimpleFuncRenameTransformer(ContextAwareTransformer, ABC):
         return updated_node.with_changes(names=new_names)
 
     @property
-    def is_function_imported(self):
+    def is_entity_imported(self):
         return self.context.scratch.get(self.ctx_key_is_imported, False)
 
+
+class BaseSimpleFuncRenameTransformer(BaseSimpleRenameTransformer, ABC):
+    """Base class to help rename or move a function."""
+
     def leave_Call(self, original_node: Call, updated_node: Call) -> BaseExpression:
-        if self.is_function_imported and m.matches(
+        if self.is_entity_imported and m.matches(
             updated_node, m.Call(func=m.Name(self.old_name))
         ):
             updated_args = self.update_call_args(updated_node)

--- a/django_codemod/visitors/decorators.py
+++ b/django_codemod/visitors/decorators.py
@@ -1,0 +1,11 @@
+from django_codemod.constants import DJANGO_20, DJANGO_30
+from django_codemod.visitors.base import BaseSimpleRenameTransformer
+
+
+class ContextDecoratorTransformer(BaseSimpleRenameTransformer):
+    """Resolve deprecation of ``django.utils.decorators.ContextDecorator``."""
+
+    deprecated_in = DJANGO_20
+    removed_in = DJANGO_30
+    rename_from = "django.utils.decorators.ContextDecorator"
+    rename_to = "contextlib.ContextDecorator"

--- a/docs/codemods.rst
+++ b/docs/codemods.rst
@@ -13,6 +13,7 @@ Applied by passing the ``--removed-in 3.0`` or ``--deprecated-in 2.0`` option:
 - Replaces ``django.utils.lru_cache.lru_cache()`` by the function it's an alias of: ``functools.lru_cache()``.
 - Replaces ``django.utils._os.abspathu()`` by the function it's an alias of: ``os.path.abspath()``.
 - Replaces ``django.utils.encoding.python_2_unicode_compatible()`` by the function it's an alias of: ``six.python_2_unicode_compatible()``.
+- Replaces ``django.utils.decorators.ContextDecorator`` by the class from the standard library it's an alias to ``contextlib.ContextDecorator``.
 
 Applied by passing the ``--removed-in 3.0`` or ``--deprecated-in 2.1`` option:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,7 @@ def test_deprecated_in_mapping():
         (2, 1): ["InlineHasAddPermissionsTransformer"],
         (2, 0): [
             "AbsPathTransformer",
+            "ContextDecoratorTransformer",
             "LRUCacheTransformer",
             "RenderToResponseTransformer",
             "UnicodeCompatibleTransformer",
@@ -210,6 +211,7 @@ def test_removed_in_mapping():
         ],
         (3, 0): [
             "AbsPathTransformer",
+            "ContextDecoratorTransformer",
             "InlineHasAddPermissionsTransformer",
             "LRUCacheTransformer",
             "RenderToResponseTransformer",

--- a/tests/visitors/test_decorators.py
+++ b/tests/visitors/test_decorators.py
@@ -1,0 +1,34 @@
+from django_codemod.visitors.decorators import ContextDecoratorTransformer
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestContextDecoratorTransformer(BaseVisitorTest):
+
+    transformer = ContextDecoratorTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.decorators import ContextDecorator
+
+            class mycontext(ContextDecorator):
+                def __enter__(self):
+                    print('Starting')
+                    return self
+
+                def __exit__(self, *exc):
+                    print('Finishing')
+                    return False
+        """
+        after = """
+            from contextlib import ContextDecorator
+
+            class mycontext(ContextDecorator):
+                def __enter__(self):
+                    print('Starting')
+                    return self
+
+                def __exit__(self, *exc):
+                    print('Finishing')
+                    return False
+        """
+        self.assertCodemod(before, after)


### PR DESCRIPTION
As per [Django 3.0 release notes](https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis):

> `django.utils.decorators.ContextDecorator` - Alias of `contextlib.ContextDecorator`.