### PR TITLE
Resolve deprecation of `django.utils.decorators.available_attrs` in Django 2.0

### DIFF
--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -1,5 +1,5 @@
 from .admin import InlineHasAddPermissionsTransformer
-from .decorators import ContextDecoratorTransformer
+from .decorators import AvailableAttrsTransformer, ContextDecoratorTransformer
 from .encoding import (
     ForceTextTransformer,
     SmartTextTransformer,
@@ -27,6 +27,7 @@ from .urls import URLTransformer
 
 __all__ = (
     "AbsPathTransformer",
+    "AvailableAttrsTransformer",
     "ContextDecoratorTransformer",
     "ForceTextTransformer",
     "HttpUrlQuotePlusTransformer",

--- a/django_codemod/visitors/decorators.py
+++ b/django_codemod/visitors/decorators.py
@@ -1,3 +1,6 @@
+from libcst import BaseExpression, Call, Name
+from libcst import matchers as m
+
 from django_codemod.constants import DJANGO_20, DJANGO_30
 from django_codemod.visitors.base import BaseSimpleRenameTransformer
 
@@ -9,3 +12,19 @@ class ContextDecoratorTransformer(BaseSimpleRenameTransformer):
     removed_in = DJANGO_30
     rename_from = "django.utils.decorators.ContextDecorator"
     rename_to = "contextlib.ContextDecorator"
+
+
+class AvailableAttrsTransformer(BaseSimpleRenameTransformer):
+    """Resolve deprecation of ``django.utils.decorators.available_attrs``."""
+
+    deprecated_in = DJANGO_20
+    removed_in = DJANGO_30
+    rename_from = "django.utils.decorators.available_attrs"
+    rename_to = "functools.WRAPPER_ASSIGNMENTS"
+
+    def leave_Call(self, original_node: Call, updated_node: Call) -> BaseExpression:
+        if self.is_entity_imported and m.matches(
+            updated_node, m.Call(func=m.Name(self.old_name))
+        ):
+            return Name(self.new_name)
+        return super().leave_Call(original_node, updated_node)

--- a/docs/codemods.rst
+++ b/docs/codemods.rst
@@ -14,6 +14,7 @@ Applied by passing the ``--removed-in 3.0`` or ``--deprecated-in 2.0`` option:
 - Replaces ``django.utils._os.abspathu()`` by the function it's an alias of: ``os.path.abspath()``.
 - Replaces ``django.utils.encoding.python_2_unicode_compatible()`` by the function it's an alias of: ``six.python_2_unicode_compatible()``.
 - Replaces ``django.utils.decorators.ContextDecorator`` by the class from the standard library it's an alias to ``contextlib.ContextDecorator``.
+- Replace ``django.utils.decorators.available_attrs()`` by its return value ``functools.WRAPPER_ASSIGNMENTS``.
 
 Applied by passing the ``--removed-in 3.0`` or ``--deprecated-in 2.1`` option:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,7 @@ def test_deprecated_in_mapping():
         (2, 1): ["InlineHasAddPermissionsTransformer"],
         (2, 0): [
             "AbsPathTransformer",
+            "AvailableAttrsTransformer",
             "ContextDecoratorTransformer",
             "LRUCacheTransformer",
             "RenderToResponseTransformer",
@@ -211,6 +212,7 @@ def test_removed_in_mapping():
         ],
         (3, 0): [
             "AbsPathTransformer",
+            "AvailableAttrsTransformer",
             "ContextDecoratorTransformer",
             "InlineHasAddPermissionsTransformer",
             "LRUCacheTransformer",

--- a/tests/visitors/test_decorators.py
+++ b/tests/visitors/test_decorators.py
@@ -1,4 +1,7 @@
-from django_codemod.visitors.decorators import ContextDecoratorTransformer
+from django_codemod.visitors.decorators import (
+    AvailableAttrsTransformer,
+    ContextDecoratorTransformer,
+)
 from tests.visitors.base import BaseVisitorTest
 
 
@@ -30,5 +33,33 @@ class TestContextDecoratorTransformer(BaseVisitorTest):
                 def __exit__(self, *exc):
                     print('Finishing')
                     return False
+        """
+        self.assertCodemod(before, after)
+
+
+class TestAvailableAttrsTransformer(BaseVisitorTest):
+
+    transformer = AvailableAttrsTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.utils.decorators import available_attrs
+
+            def my_decorator(func):
+                @wraps(func, assigned=available_attrs(func))
+                def inner(*args, **kwargs):
+                    return func(*args, **kwargs)
+
+                return inner
+        """
+        after = """
+            from functools import WRAPPER_ASSIGNMENTS
+
+            def my_decorator(func):
+                @wraps(func, assigned=WRAPPER_ASSIGNMENTS)
+                def inner(*args, **kwargs):
+                    return func(*args, **kwargs)
+
+                return inner
         """
         self.assertCodemod(before, after)


### PR DESCRIPTION
One of the Python 2 compatibility API, from [Django 3.0 release notes](https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis):

> `django.utils.decorators.available_attrs()` - This function returns `functools.WRAPPER_ASSIGNMENTS`.