### PR TITLE
Add support for adding `on_delete` for `ForeignKey` and `OneToOneField`

### DIFF
--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -39,6 +39,7 @@ __all__ = (
     "IsSafeUrlTransformer",
     "LRUCacheTransformer",
     "ModelsPermalinkTransformer",
+    "OnDeleteTransformer",
     "RenderToResponseTransformer",
     "SmartTextTransformer",
     "UGetTextLazyTransformer",

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -14,7 +14,7 @@ from .http import (
     IsSafeUrlTransformer,
 )
 from .lru_cache import LRUCacheTransformer
-from .models import ModelsPermalinkTransformer
+from .models import ModelsPermalinkTransformer, OnDeleteTransformer
 from .os_utils import AbsPathTransformer
 from .shortcuts import RenderToResponseTransformer
 from .translations import (

--- a/django_codemod/visitors/models.py
+++ b/django_codemod/visitors/models.py
@@ -20,7 +20,7 @@ from libcst.codemod import ContextAwareTransformer
 from libcst.codemod.visitors import AddImportsVisitor
 
 from django_codemod.constants import DJANGO_19, DJANGO_20, DJANGO_21, DJANGO_111
-from django_codemod.visitors.base import module_matcher
+from django_codemod.visitors.base import BaseSimpleFuncRenameTransformer, module_matcher
 
 
 class ModelsPermalinkTransformer(ContextAwareTransformer):
@@ -161,6 +161,9 @@ class OnDeleteTransformer(ContextAwareTransformer):
         if (
             is_one_to_one_field(original_node) or is_foreign_key(original_node)
         ) and not has_on_delete(original_node):
+            AddImportsVisitor.add_needed_import(
+                context=self.context, module="django.db", obj="models",
+            )
             updated_args = (
                 *updated_node.args,
                 Arg(

--- a/django_codemod/visitors/models.py
+++ b/django_codemod/visitors/models.py
@@ -171,7 +171,7 @@ class OnDeleteTransformer(ContextAwareTransformer):
                 *updated_node.args,
                 Arg(
                     keyword=Name("on_delete"),
-                    value=Attribute(value=Name("models"), attr=Name("CASCADE"),),
+                    value=Attribute(value=Name("models"), attr=Name("CASCADE")),
                 ),
             )
             return updated_node.with_changes(args=updated_args)

--- a/django_codemod/visitors/models.py
+++ b/django_codemod/visitors/models.py
@@ -139,7 +139,7 @@ def is_foreign_key(node: Call) -> bool:
 
 def is_one_to_one_field(node: Call) -> bool:
     return m.matches(
-        node, m.Call(func=m.Attribute(attr=m.Name(value="OneToOneField")),),
+        node, m.Call(func=m.Attribute(attr=m.Name(value="OneToOneField"))),
     )
 
 

--- a/django_codemod/visitors/models.py
+++ b/django_codemod/visitors/models.py
@@ -146,7 +146,7 @@ def is_one_to_one_field(node: Call) -> bool:
 def has_on_delete(node: Call) -> bool:
     # if on_delete exists in any kwarg we return True
     for arg in node.args:
-        if m.matches(arg.keyword, m.Name("on_delete")):
+        if m.matches(arg, m.Arg(keyword=m.Name("on_delete"))):
             return True
 
     # if there are two or more nodes and there are no keywords

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,6 +189,7 @@ def test_deprecated_in_mapping():
             "UnicodeCompatibleTransformer",
         ],
         (1, 11): ["ModelsPermalinkTransformer"],
+        (1, 9): ["OnDeleteTransformer"],
     }
 
 
@@ -221,4 +222,5 @@ def test_removed_in_mapping():
             "UnicodeCompatibleTransformer",
         ],
         (2, 1): ["ModelsPermalinkTransformer"],
+        (2, 0): ["OnDeleteTransformer"],
     }

--- a/tests/visitors/test_models.py
+++ b/tests/visitors/test_models.py
@@ -1,7 +1,54 @@
 from parameterized import parameterized
 
-from django_codemod.visitors.models import ModelsPermalinkTransformer
+from django_codemod.visitors.models import ModelsPermalinkTransformer, OnDeleteTransformer
 from tests.visitors.base import BaseVisitorTest
+
+
+class TestOnDeleteTransformer(BaseVisitorTest):
+
+    transformer = OnDeleteTransformer
+
+    def test_foreign_key(self) -> None:
+        pass
+
+    def test_one_to_one_field(self) -> None:
+        before = """
+            from django.db import models
+
+            class MyModel(models.Model):
+                operations = [
+                    migrations.CreateModel(
+                        fields=[
+                            (
+                                'model',
+                                models.OneToOneField(to = 'random.Model'),
+                            ),
+                        ],
+                    )
+                ]
+        """
+        after = """
+            from django.db import models
+
+            class MyModel(models.Model):
+                operations = [
+                    migrations.CreateModel(
+                        fields=[
+                            (
+                                'model',
+                                models.OneToOneField(to = 'random.Model', on_delete = models.CASCADE),
+                            ),
+                        ],
+                    )
+                ]
+        """
+        self.assertCodemod(before, after)
+
+    def test_on_delete_already_exists(self) -> None:
+        pass
+
+    def test_add_import(self) -> None:
+        pass
 
 
 class TestAvailableAttrsTransformer(BaseVisitorTest):

--- a/tests/visitors/test_models.py
+++ b/tests/visitors/test_models.py
@@ -88,7 +88,17 @@ class TestOnDeleteTransformer(BaseVisitorTest):
         self.assertCodemod(before, after)
 
     def test_positional_args_without_on_delete(self) -> None:
-        pass
+        before = """
+            from django.db import models
+
+            models.OneToOneField('model')
+        """
+        after = """
+            from django.db import models
+
+            models.OneToOneField('model', on_delete = models.CASCADE)
+        """
+        self.assertCodemod(before, after)
 
     def test_positional_args_with_on_delete(self) -> None:
         # shouldn't do anything
@@ -116,10 +126,44 @@ class TestOnDeleteTransformer(BaseVisitorTest):
 
     ## testing the model import for models.CASCADE
     def test_add_model_import(self) -> None:
-        pass
+        before = """
+            from random.place import CustomModel
 
-    def test_dont_add_model_import_if_it_exists(self) -> None:
-        pass
+            class MyModel(CustomModel):
+                operations = [
+                    migrations.CreateModel(
+                        fields=[
+                            (
+                                'field_name',
+                                CustomModel.OneToOneField(
+                                    'model.Location',
+                                    auto_created=True,
+                                ),
+                            ),
+                        ],
+                    )
+                ]
+        """
+        after = """
+            from random.place import CustomModel
+            from django.db import models
+
+            class MyModel(CustomModel):
+                operations = [
+                    migrations.CreateModel(
+                        fields=[
+                            (
+                                'field_name',
+                                CustomModel.OneToOneField(
+                                    'model.Location',
+                                    auto_created=True,
+                                on_delete = models.CASCADE),
+                            ),
+                        ],
+                    )
+                ]
+        """
+        self.assertCodemod(before, after)
 
 
 class TestAvailableAttrsTransformer(BaseVisitorTest):

--- a/tests/visitors/test_models.py
+++ b/tests/visitors/test_models.py
@@ -12,7 +12,17 @@ class TestOnDeleteTransformer(BaseVisitorTest):
     transformer = OnDeleteTransformer
 
     def test_foreign_key(self) -> None:
-        pass
+        before = """
+            class MyModel(models.Model):
+                user = models.ForeignKey('auth.User')
+        """
+        after = """
+            from django.db import models
+
+            class MyModel(models.Model):
+                user = models.ForeignKey('auth.User', on_delete = models.CASCADE)
+        """
+        self.assertCodemod(before, after)
 
     def test_one_to_one_field(self) -> None:
         before = """
@@ -45,9 +55,8 @@ class TestOnDeleteTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
-    # testing our on_delete detector works as expected in
-    # all the little edge cases
     def test_multiple_kwargs_with_on_delete(self) -> None:
+        """ Should do nothing """
         before = """
             from django.db import models
 
@@ -131,7 +140,7 @@ class TestOnDeleteTransformer(BaseVisitorTest):
         self.assertCodemod(before, after)
 
     def test_positional_args_with_on_delete(self) -> None:
-        # shouldn't do anything
+        """ Should do nothing """
         before = """
             from django.db import models
 
@@ -174,7 +183,6 @@ class TestOnDeleteTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
-    # testing the model import for models.CASCADE
     def test_add_model_import(self) -> None:
         before = """
             from random.place import CustomModel

--- a/tests/visitors/test_models.py
+++ b/tests/visitors/test_models.py
@@ -26,32 +26,14 @@ class TestOnDeleteTransformer(BaseVisitorTest):
 
     def test_one_to_one_field(self) -> None:
         before = """
-            from django.db import models
-
             class MyModel(models.Model):
-                migrations.CreateModel(
-                    fields=[
-                        (
-                            'model',
-                            models.OneToOneField(
-                                to = 'random.Model'),
-                        ),
-                    ],
-                )
+                user = models.OneToOneField('auth.User')
         """
         after = """
             from django.db import models
 
             class MyModel(models.Model):
-                migrations.CreateModel(
-                    fields=[
-                        (
-                            'model',
-                            models.OneToOneField(
-                                to = 'random.Model', on_delete = models.CASCADE),
-                        ),
-                    ],
-                )
+                user = models.OneToOneField('auth.User', on_delete = models.CASCADE)
         """
         self.assertCodemod(before, after)
 


### PR DESCRIPTION
Adding a feature to handle adding the `on_delete` argument to `ForeignKey` and `OneToOneField` types: https://docs.djangoproject.com/en/dev/releases/1.9/#foreignkey-and-onetoonefield-on-delete-argument

TODO:
- [x] Add some more tests
- [x] Address adding the `models` import if it doesn't exist
- [x] Support detecting the `on_delete` call when passed as the second position argument
- [x] Fix `on_delete` matcher which doesn't seem to be finding things right
- [x] Test internally with a complicated codebase 💃 

Stretch:
- [ ] ~Add an input so folks can add in subclasses~ (_Edit: Probably going to do this in a future PR)_