### PR TITLE
Internal refactoring of CLI and test improvements

### DIFF
--- a/django_codemod/cli.py
+++ b/django_codemod/cli.py
@@ -121,17 +121,8 @@ def djcodemod(removed_in, deprecated_in, path):
         codemodders_list = REMOVED_IN[removed_in]
     else:
         codemodders_list = DEPRECATED_IN[deprecated_in]
-    command_instance = build_command(codemodders_list)
+    command_instance = BaseCodemodCommand(codemodders_list, CodemodContext())
     call_command(command_instance, path)
-
-
-def build_command(codemodders_list: List) -> BaseCodemodCommand:
-    """Build a custom command with the list of visitors."""
-
-    class CustomCommand(BaseCodemodCommand):
-        transformers = codemodders_list
-
-    return CustomCommand(CodemodContext())
 
 
 def call_command(command_instance: BaseCodemodCommand, path: str):

--- a/django_codemod/commands.py
+++ b/django_codemod/commands.py
@@ -2,13 +2,21 @@ from abc import ABC
 from typing import List, Type
 
 import libcst as cst
-from libcst.codemod import ContextAwareTransformer, VisitorBasedCodemodCommand
+from libcst.codemod import (
+    CodemodContext,
+    ContextAwareTransformer,
+    VisitorBasedCodemodCommand,
+)
 
 
 class BaseCodemodCommand(VisitorBasedCodemodCommand, ABC):
     """Base class for our commands."""
 
     transformers: List[Type[ContextAwareTransformer]]
+
+    def __init__(self, transformers, context: CodemodContext) -> None:
+        self.transformers = transformers
+        super().__init__(context)
 
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
         for transform in self.transformers:

--- a/tests/visitors/base.py
+++ b/tests/visitors/base.py
@@ -8,10 +8,6 @@ class BaseVisitorTest(CodemodTest):
 
     transformer = None
 
-    def TRANSFORM(self, context, *args, **kwargs):
+    def TRANSFORM(self, context):
         """Create a command for the transformer under test."""
-
-        class TransformerCommand(BaseCodemodCommand):
-            transformers = [self.transformer]
-
-        return TransformerCommand(context, *args, **kwargs)
+        return BaseCodemodCommand([self.transformer], context)


### PR DESCRIPTION
This change enables us to test the CLI without patching our own function, to have a test running the whole code path.