### PR TITLE
New visitor to replace `timezone.FixedOffset` by `datetime.timezone`

### DIFF
--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -18,6 +18,7 @@ from .lru_cache import LRUCacheTransformer
 from .models import ModelsPermalinkTransformer, OnDeleteTransformer
 from .os_utils import AbsPathTransformer
 from .shortcuts import RenderToResponseTransformer
+from .timezone import FixedOffsetTransformer
 from .translations import (
     UGetTextLazyTransformer,
     UGetTextNoopTransformer,
@@ -31,6 +32,7 @@ __all__ = (
     "AbsPathTransformer",
     "AvailableAttrsTransformer",
     "ContextDecoratorTransformer",
+    "FixedOffsetTransformer",
     "ForceTextTransformer",
     "HttpUrlQuotePlusTransformer",
     "HttpUrlQuoteTransformer",

--- a/django_codemod/visitors/timezone.py
+++ b/django_codemod/visitors/timezone.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+
+from libcst import Arg, Call, Name
+from libcst.codemod.visitors import AddImportsVisitor
+
+from django_codemod.constants import DJANGO_2_2, DJANGO_3_1
+from django_codemod.visitors.base import BaseFuncRenameTransformer
+
+
+class FixedOffsetTransformer(BaseFuncRenameTransformer):
+    """Replace `django.utils.timezone.FixedOffset` by `datetime.timezone`."""
+
+    deprecated_in = DJANGO_2_2
+    removed_in = DJANGO_3_1
+    rename_from = "django.utils.timezone.FixedOffset"
+    rename_to = "datetime.timezone"
+
+    def update_call_args(self, node: Call) -> Sequence[Arg]:
+        """Update first argument to convert integer for minutes to timedelta."""
+        AddImportsVisitor.add_needed_import(
+            context=self.context,
+            module="datetime",
+            obj="timedelta",
+        )
+        offset_arg, *other_args = node.args
+        timedelta_call = Call(
+            func=Name("timedelta"),
+            args=(Arg(keyword=Name("minutes"), value=offset_arg.value),),
+        )
+        new_offset_arg = offset_arg.with_changes(value=timedelta_call)
+        return (new_offset_arg, *other_args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,7 @@ def test_deprecated_in_mapping():
             "URLTransformer",
             "UnescapeEntitiesTransformer",
         ],
+        (2, 2): ["FixedOffsetTransformer"],
         (2, 1): ["InlineHasAddPermissionsTransformer"],
         (2, 0): [
             "AbsPathTransformer",
@@ -230,6 +231,7 @@ def test_removed_in_mapping():
             "URLTransformer",
             "UnescapeEntitiesTransformer",
         ],
+        (3, 1): ["FixedOffsetTransformer"],
         (3, 0): [
             "AbsPathTransformer",
             "AvailableAttrsTransformer",

--- a/tests/visitors/test_timezone.py
+++ b/tests/visitors/test_timezone.py
@@ -1,0 +1,77 @@
+from django_codemod.visitors import FixedOffsetTransformer
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestFixedOffsetTransformer(BaseVisitorTest):
+
+    transformer = FixedOffsetTransformer
+
+    def test_noop(self) -> None:
+        """Test when nothing should change."""
+        before = after = """
+            from datetime import timedelta, timezone
+
+            timezone(offset=timedelta(minutes=60))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_without_name_kwargs(self) -> None:
+        """Case with just offset given as kwarg."""
+        before = """
+            from django.utils.timezone import FixedOffset
+
+            tz_info = FixedOffset(offset=60)
+        """
+        after = """
+            from datetime import timedelta, timezone
+
+            tz_info = timezone(offset=timedelta(minutes = 60))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_without_name_args(self) -> None:
+        """Case with just offset given as arg."""
+        before = """
+            from django.utils.timezone import FixedOffset
+
+            tz_info = FixedOffset(60)
+        """
+        after = """
+            from datetime import timedelta, timezone
+
+            tz_info = timezone(timedelta(minutes = 60))
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_with_name_kwargs(self) -> None:
+        """Case with both offset and name given as kwargs."""
+        before = """
+            from django.utils.timezone import FixedOffset
+
+            tz_info = FixedOffset(offset=60, name="example")
+        """
+        after = """
+            from datetime import timedelta, timezone
+
+            tz_info = timezone(offset=timedelta(minutes = 60), name="example")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_with_name_args(self) -> None:
+        """Case with both offset and name given as args."""
+        before = """
+            from django.utils.timezone import FixedOffset
+
+            tz_info = FixedOffset(60, "example")
+        """
+        after = """
+            from datetime import timedelta, timezone
+
+            tz_info = timezone(timedelta(minutes = 60), "example")
+        """
+
+        self.assertCodemod(before, after)


### PR DESCRIPTION
> `django.utils.timezone.FixedOffset` is deprecated in favor of `datetime.timezone`