### PR TITLE
New visitor to replace usages of `QuerySetPaginator`

### DIFF
--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -17,6 +17,7 @@ from .http import (
 from .lru_cache import LRUCacheTransformer
 from .models import ModelsPermalinkTransformer, OnDeleteTransformer
 from .os_utils import AbsPathTransformer
+from .paginator import QuerySetPaginatorTransformer
 from .shortcuts import RenderToResponseTransformer
 from .timezone import FixedOffsetTransformer
 from .translations import (
@@ -43,6 +44,7 @@ __all__ = (
     "LRUCacheTransformer",
     "ModelsPermalinkTransformer",
     "OnDeleteTransformer",
+    "QuerySetPaginatorTransformer",
     "RenderToResponseTransformer",
     "SmartTextTransformer",
     "UGetTextLazyTransformer",

--- a/django_codemod/visitors/paginator.py
+++ b/django_codemod/visitors/paginator.py
@@ -1,0 +1,11 @@
+from django_codemod.constants import DJANGO_2_2, DJANGO_3_1
+from django_codemod.visitors.base import BaseFuncRenameTransformer
+
+
+class QuerySetPaginatorTransformer(BaseFuncRenameTransformer):
+    """Replace `QuerySetPaginator` class by `Paginator`."""
+
+    deprecated_in = DJANGO_2_2
+    removed_in = DJANGO_3_1
+    rename_from = "django.core.paginator.QuerySetPaginator"
+    rename_to = "django.core.paginator.Paginator"

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -49,6 +49,13 @@ Applied by passing the `--removed-in 3.0` or `--deprecated-in 2.1` option:
 
 -   Add the `obj` argument to `InlineModelAdmin.has_add_permission()`.
 
+## Removed in Django 3.1
+
+Applied by passing the `--removed-in 3.1` or `--deprecated-in 2.2` option:
+
+-   Replace `django.utils.timezone.FixedOffset` by `datetime.timezone`.
+-   Replace `django.core.paginator.QuerySetPaginator` class by `Paginator`.
+
 ## Removed in Django 4.0
 
 Applied by passing the `--removed-in 4.0` or `--deprecated-in 3.0` option:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,8 +196,13 @@ def test_deprecated_in_mapping():
             "URLTransformer",
             "UnescapeEntitiesTransformer",
         ],
-        (2, 2): ["FixedOffsetTransformer"],
-        (2, 1): ["InlineHasAddPermissionsTransformer"],
+        (2, 2): [
+            "FixedOffsetTransformer",
+            "QuerySetPaginatorTransformer",
+        ],
+        (2, 1): [
+            "InlineHasAddPermissionsTransformer",
+        ],
         (2, 0): [
             "AbsPathTransformer",
             "AvailableAttrsTransformer",
@@ -206,9 +211,15 @@ def test_deprecated_in_mapping():
             "RenderToResponseTransformer",
             "UnicodeCompatibleTransformer",
         ],
-        (1, 11): ["ModelsPermalinkTransformer"],
-        (1, 10): ["URLResolversTransformer"],
-        (1, 9): ["OnDeleteTransformer"],
+        (1, 11): [
+            "ModelsPermalinkTransformer",
+        ],
+        (1, 10): [
+            "URLResolversTransformer",
+        ],
+        (1, 9): [
+            "OnDeleteTransformer",
+        ],
     }
 
 
@@ -231,7 +242,10 @@ def test_removed_in_mapping():
             "URLTransformer",
             "UnescapeEntitiesTransformer",
         ],
-        (3, 1): ["FixedOffsetTransformer"],
+        (3, 1): [
+            "FixedOffsetTransformer",
+            "QuerySetPaginatorTransformer",
+        ],
         (3, 0): [
             "AbsPathTransformer",
             "AvailableAttrsTransformer",
@@ -241,8 +255,13 @@ def test_removed_in_mapping():
             "RenderToResponseTransformer",
             "UnicodeCompatibleTransformer",
         ],
-        (2, 1): ["ModelsPermalinkTransformer"],
-        (2, 0): ["OnDeleteTransformer", "URLResolversTransformer"],
+        (2, 1): [
+            "ModelsPermalinkTransformer",
+        ],
+        (2, 0): [
+            "OnDeleteTransformer",
+            "URLResolversTransformer",
+        ],
     }
 
 

--- a/tests/visitors/test_paginator.py
+++ b/tests/visitors/test_paginator.py
@@ -1,0 +1,47 @@
+from django_codemod.visitors import QuerySetPaginatorTransformer
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestQuerySetPaginatorTransformer(BaseVisitorTest):
+
+    transformer = QuerySetPaginatorTransformer
+
+    def test_noop(self) -> None:
+        """Test when nothing should change."""
+        before = after = """
+            from django.core.paginator import Paginator
+
+            paginator_instance = Paginator([], 5)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_instance_replacement(self) -> None:
+        """Replace instantiation of the class."""
+        before = """
+            from django.core.paginator import QuerySetPaginator
+
+            paginator_instance = QuerySetPaginator([], 5)
+        """
+        after = """
+            from django.core.paginator import Paginator
+
+            paginator_instance = Paginator([], 5)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_reference_replacement(self) -> None:
+        """Replace simple reference to the class."""
+        before = """
+            from django.core.paginator import QuerySetPaginator
+
+            paginator_class = QuerySetPaginator
+        """
+        after = """
+            from django.core.paginator import Paginator
+
+            paginator_class = Paginator
+        """
+
+        self.assertCodemod(before, after)


### PR DESCRIPTION
From Django 2.2 release notes:

> The undocumented `QuerySetPaginator` alias of `django.core.paginator.Paginator` is deprecated

This is removed in Django 3.1