### PR TITLE
Add visitor to replace usages of postgres' `FloatRangeFormField`

### DIFF
--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -18,6 +18,10 @@ from .lru_cache import LRUCacheTransformer
 from .models import ModelsPermalinkTransformer, OnDeleteTransformer
 from .os_utils import AbsPathTransformer
 from .paginator import QuerySetPaginatorTransformer
+from .postgres_fields import (
+    FloatRangeFormFieldTransformer,
+    FloatRangeModelFieldTransformer,
+)
 from .shortcuts import RenderToResponseTransformer
 from .timezone import FixedOffsetTransformer
 from .translations import (
@@ -34,6 +38,8 @@ __all__ = (
     "AvailableAttrsTransformer",
     "ContextDecoratorTransformer",
     "FixedOffsetTransformer",
+    "FloatRangeFormFieldTransformer",
+    "FloatRangeModelFieldTransformer",
     "ForceTextTransformer",
     "HttpUrlQuotePlusTransformer",
     "HttpUrlQuoteTransformer",

--- a/django_codemod/visitors/postgres_fields.py
+++ b/django_codemod/visitors/postgres_fields.py
@@ -1,0 +1,20 @@
+from django_codemod.constants import DJANGO_2_2, DJANGO_3_1
+from django_codemod.visitors.base import BaseFuncRenameTransformer
+
+
+class FloatRangeModelFieldTransformer(BaseFuncRenameTransformer):
+    """Replace postgres' model field `FloatRangeField` by `DecimalRangeField`."""
+
+    deprecated_in = DJANGO_2_2
+    removed_in = DJANGO_3_1
+    rename_from = "django.contrib.postgres.fields.FloatRangeField"
+    rename_to = "django.contrib.postgres.fields.DecimalRangeField"
+
+
+class FloatRangeFormFieldTransformer(BaseFuncRenameTransformer):
+    """Replace postgres' form field `FloatRangeField` by `DecimalRangeField`."""
+
+    deprecated_in = DJANGO_2_2
+    removed_in = DJANGO_3_1
+    rename_from = "django.contrib.postgres.forms.FloatRangeField"
+    rename_to = "django.contrib.postgres.forms.DecimalRangeField"

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -55,6 +55,8 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 2.2` option:
 
 -   Replace `django.utils.timezone.FixedOffset` by `datetime.timezone`.
 -   Replace `django.core.paginator.QuerySetPaginator` class by `Paginator`.
+-   Replace the `FloatRangeField` model and form fields in 
+    `django.contrib.postgres` by `DecimalRangeField`.
 
 ## Removed in Django 4.0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,6 +198,8 @@ def test_deprecated_in_mapping():
         ],
         (2, 2): [
             "FixedOffsetTransformer",
+            "FloatRangeFormFieldTransformer",
+            "FloatRangeModelFieldTransformer",
             "QuerySetPaginatorTransformer",
         ],
         (2, 1): [
@@ -244,6 +246,8 @@ def test_removed_in_mapping():
         ],
         (3, 1): [
             "FixedOffsetTransformer",
+            "FloatRangeFormFieldTransformer",
+            "FloatRangeModelFieldTransformer",
             "QuerySetPaginatorTransformer",
         ],
         (3, 0): [

--- a/tests/visitors/test_postgres_fields.py
+++ b/tests/visitors/test_postgres_fields.py
@@ -1,0 +1,65 @@
+from django_codemod.visitors import (
+    FloatRangeFormFieldTransformer,
+    FloatRangeModelFieldTransformer,
+)
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestFloatRangeModelFieldTransformer(BaseVisitorTest):
+
+    transformer = FloatRangeModelFieldTransformer
+
+    def test_noop(self) -> None:
+        """Test when nothing should change."""
+        before = after = """
+            from django.contrib.postgres.fields import DecimalRangeField
+
+            some_range = DecimalRangeField()
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_basic_replacement(self) -> None:
+        """Test simple replacement."""
+        before = """
+            from django.contrib.postgres.fields import FloatRangeField
+
+            some_range = FloatRangeField()
+        """
+        after = """
+            from django.contrib.postgres.fields import DecimalRangeField
+
+            some_range = DecimalRangeField()
+        """
+
+        self.assertCodemod(before, after)
+
+
+class TestFloatRangeFormFieldTransformer(BaseVisitorTest):
+
+    transformer = FloatRangeFormFieldTransformer
+
+    def test_noop(self) -> None:
+        """Test when nothing should change."""
+        before = after = """
+            from django.contrib.postgres.forms import DecimalRangeField
+
+            some_range = DecimalRangeField()
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_basic_replacement(self) -> None:
+        """Test simple replacement."""
+        before = """
+            from django.contrib.postgres.forms import FloatRangeField
+
+            some_range = FloatRangeField()
+        """
+        after = """
+            from django.contrib.postgres.forms import DecimalRangeField
+
+            some_range = DecimalRangeField()
+        """
+
+        self.assertCodemod(before, after)


### PR DESCRIPTION
From Django 2.2 release notes:

> The `FloatRangeField` model and form fields in `django.contrib.postgres` are deprecated in favor of a new name, `DecimalRangeField`, to match the underlying `numrange` data type used in the database.

This is removed in Django 3.1