### PR TITLE
feat: support multiple target path arguments

### DIFF
--- a/django_codemod/cli.py
+++ b/django_codemod/cli.py
@@ -102,7 +102,7 @@ def djcodemod():
 
 
 @djcodemod.command()
-@click.argument("path")
+@click.argument("path", nargs=-1, required=True)
 @click.option(
     "--removed-in",
     "removed_in",
@@ -115,7 +115,9 @@ def djcodemod():
     help="The version of Django where deprecations started.",
     type=VersionParamType(DEPRECATED_IN),
 )
-def run(removed_in: Tuple[int, int], deprecated_in: Tuple[int, int], path: str) -> None:
+def run(
+    removed_in: Tuple[int, int], deprecated_in: Tuple[int, int], path: List[str]
+) -> None:
     """
     Automatically fixes deprecations removed Django deprecations.
 
@@ -134,9 +136,9 @@ def run(removed_in: Tuple[int, int], deprecated_in: Tuple[int, int], path: str) 
     call_command(command_instance, path)
 
 
-def call_command(command_instance: BaseCodemodCommand, path: str):
+def call_command(command_instance: BaseCodemodCommand, path: List[str]):
     """Call libCST with our customized command."""
-    files = gather_files([path])
+    files = gather_files(path)
     try:
         # Super simplified call
         result = parallel_exec_transform_with_prettyprint(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,7 @@ def test_missing_argument(cli_runner):
     result = cli_runner.invoke(cli.djcodemod, ["run"])
 
     assert result.exit_code == 2
-    assert "Error: Missing argument 'PATH'" in result.output
+    assert "Error: Missing argument 'PATH" in result.output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As it says on the tin: support e.g.

```
djcodemod run --deprecated-in 3.0 package1 package2
```

or if you're even wilder, e.g.

```
git ls-files | grep 'py$' | grep -v migrations | xargs djcodemod run --deprecated-in 3.0
```