### PR TITLE
Allow both removed-in and deprecated-in

### DIFF
--- a/django_codemod/cli.py
+++ b/django_codemod/cli.py
@@ -73,7 +73,7 @@ class VersionParamType(click.ParamType):
         if parsed_version not in self.valid_versions:
             supported_versions = ", ".join(
                 ".".join(str(version_part) for version_part in version_tuple)
-                for version_tuple in self.valid_versions
+                for version_tuple in sorted(self.valid_versions)
             )
             self.fail(
                 f"{value!r} is not supported. "

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,7 @@ This package provides a `djcodemod` command line tool with 2 main supported work
 - Prepare future upgrades by modifying code which is deprecated in a given version using the `deprecated-in` option
 - Fix previous deprecated code which is removed in a given version using the `removed-in` option
 
-## Workflows 
+## Workflows
 
 ### Deprecations
 
@@ -24,6 +24,10 @@ This is more a just in time operation, assuming you haven't kept up to date with
 ```bash
 djcodemod run --removed-in 4.0 .
 ```
+
+### Mix and match
+
+Both `--deprecated-in` and `--removed-in` can be passed at once, and both accept multiple repetitions.
 
 ## Next steps
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,24 +41,12 @@ def test_missing_argument(cli_runner):
     assert "Error: Missing argument 'PATH" in result.output
 
 
-@pytest.mark.parametrize(
-    "command_line",
-    [
-        # Missing options
-        ["run", "."],
-        # Too many options
-        ["run", "--removed-in", "3.0", "--deprecated-in", "2.0", "."],
-    ],
-)
-def test_invalid_options(cli_runner, command_line):
+def test_no_mods_selected(cli_runner):
     """Should explain missing option."""
-    result = cli_runner.invoke(cli.djcodemod, command_line)
+    result = cli_runner.invoke(cli.djcodemod, ["run", "."])
 
     assert result.exit_code == 2
-    assert (
-        "Error: You must specify either '--removed-in' or "
-        "'--deprecated-in' but not both." in result.output
-    )
+    assert "No codemods were selected" in result.output
 
 
 def test_help(cli_runner):


### PR DESCRIPTION
<del>I'm not sure if this is a bit controversial since the original explicitly only allowed either option, but I don't see harm in a "just bring me up to date fam" option (speaking of which, `--all` could be added separately).</del>

* makes `--removed-in` and `--deprecated-in` repeatable
* allows mixing and matching the two
<del>* adds an `--all` option</del>