### PR TITLE
Add codemod to add a length parameter to get_random_string()

### DIFF
--- a/django_codemod/utils/calls.py
+++ b/django_codemod/utils/calls.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from libcst import Arg
+from libcst import matchers as m
+
+
+def find_keyword_arg(args, keyword_name: str) -> Optional[Arg]:
+    matcher = m.Arg(keyword=m.Name(keyword_name))
+    for arg in args:
+        if m.matches(arg, matcher):
+            return arg
+    return None

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -1,5 +1,6 @@
 from .admin import InlineHasAddPermissionsTransformer
 from .core import URLResolversTransformer
+from .crypto import GetRandomStringTransformer
 from .decorators import AvailableAttrsTransformer, ContextDecoratorTransformer
 from .encoding import (
     ForceTextTransformer,
@@ -46,6 +47,7 @@ __all__ = (
     "FloatRangeFormFieldTransformer",
     "FloatRangeModelFieldTransformer",
     "ForceTextTransformer",
+    "GetRandomStringTransformer",
     "HttpRequestXReadLinesTransformer",
     "HttpUrlQuotePlusTransformer",
     "HttpUrlQuoteTransformer",

--- a/django_codemod/visitors/base.py
+++ b/django_codemod/visitors/base.py
@@ -105,10 +105,11 @@ class BaseRenameTransformer(BaseDjCodemodTransformer, ABC):
         for import_alias in old_names:
             if not self.old_name or import_alias.evaluated_name == self.old_name:
                 self.context.scratch[self.ctx_key_imported_as] = import_alias.asname
-                if self.simple_rename:
-                    self.add_new_import(import_alias.evaluated_name)
-            else:
-                yield import_alias
+                if self.rename_from != self.rename_to:
+                    if self.simple_rename:
+                        self.add_new_import(import_alias.evaluated_name)
+                    continue
+            yield import_alias
 
     def tidy_new_imported_names(self, new_names):
         """Tidy up the updated list of imports"""

--- a/django_codemod/visitors/crypto.py
+++ b/django_codemod/visitors/crypto.py
@@ -1,0 +1,36 @@
+from typing import Sequence
+
+from libcst import Arg, Call, Integer
+
+from django_codemod.constants import DJANGO_3_1, DJANGO_4_0
+from django_codemod.utils.calls import find_keyword_arg
+from django_codemod.visitors.base import BaseFuncRenameTransformer
+
+
+class GetRandomStringTransformer(BaseFuncRenameTransformer):
+    """Update lengthless uses of get_random_string()"""
+
+    deprecated_in = DJANGO_3_1
+    removed_in = DJANGO_4_0
+    rename_from = "django.utils.crypto.get_random_string"
+    rename_to = "django.utils.crypto.get_random_string"
+
+    # The default value Django specifies is 12.
+    default_length_value = Integer("12")
+
+    def update_call_args(self, node: Call) -> Sequence[Arg]:
+        # No args? Just add the default 12.
+        if not node.args:
+            return [Arg(value=self.default_length_value)]
+
+        # If there's only an allowed chars kwarg, prepend the length arg.
+        allowed_chars_kwarg = find_keyword_arg(node.args, "allowed_chars")
+
+        if len(node.args) == 1 and allowed_chars_kwarg:
+            return [
+                Arg(value=self.default_length_value),
+                allowed_chars_kwarg,
+            ]
+
+        # Otherwise don't do anything.
+        return node.args

--- a/django_codemod/visitors/models.py
+++ b/django_codemod/visitors/models.py
@@ -19,6 +19,7 @@ from libcst import matchers as m
 from libcst.codemod.visitors import AddImportsVisitor
 
 from django_codemod.constants import DJANGO_1_9, DJANGO_1_11, DJANGO_2_0, DJANGO_2_1
+from django_codemod.utils.calls import find_keyword_arg
 from django_codemod.visitors.base import BaseDjCodemodTransformer, module_matcher
 
 
@@ -148,9 +149,8 @@ def is_one_to_one_field(node: Call) -> bool:
 
 def has_on_delete(node: Call) -> bool:
     # if on_delete exists in any kwarg we return True
-    for arg in node.args:
-        if m.matches(arg, m.Arg(keyword=m.Name("on_delete"))):
-            return True
+    if find_keyword_arg(node.args, "on_delete"):
+        return True
 
     # if there are two or more nodes and there are no keywords
     # then we can assume that positional arguments are being used

--- a/tests/visitors/test_crypto.py
+++ b/tests/visitors/test_crypto.py
@@ -1,0 +1,87 @@
+from django_codemod.visitors.crypto import GetRandomStringTransformer
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestGetRandomStringTransformer(BaseVisitorTest):
+
+    transformer = GetRandomStringTransformer
+
+    def test_noop_1(self) -> None:
+        """Test when nothing should change."""
+        before = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(16)
+        """
+
+        after = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(16)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_noop_2(self) -> None:
+        """Test when nothing should change."""
+        before = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(16, allowed_chars="abc")
+        """
+
+        after = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(16, allowed_chars="abc")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_noop_3(self) -> None:
+        """Test when nothing should change."""
+        before = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(length=16, allowed_chars="abc")
+        """
+
+        after = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(length=16, allowed_chars="abc")
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_simple_substitution(self) -> None:
+        """Test adding the length parameter."""
+        before = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string()
+        """
+
+        after = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(12)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_allowed_chars_present(self) -> None:
+        """Test adding the length parameter when allowed_chars is present."""
+        before = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(allowed_chars="abc")
+        """
+
+        after = """
+        from django.utils.crypto import get_random_string
+
+        get_random_string(12, allowed_chars="abc")
+        """
+
+        self.assertCodemod(before, after)


### PR DESCRIPTION
Not passing a length to `get_random_string()` is deprecated in Django 3.1