### PR TITLE
Allow running specific codemod(s)

### DIFF
--- a/django_codemod/cli.py
+++ b/django_codemod/cli.py
@@ -36,7 +36,9 @@ def iter_codemodders() -> Generator[BaseDjCodemodTransformer, None, None]:
     for object_name in dir(visitors):
         try:
             obj = getattr(visitors, object_name)
-            if issubclass(obj, BaseDjCodemodTransformer) and not inspect.isabstract(obj):
+            if issubclass(obj, BaseDjCodemodTransformer) and not inspect.isabstract(
+                obj
+            ):
                 yield obj  # Looks like this one is good to go
         except TypeError:
             continue

--- a/django_codemod/cli.py
+++ b/django_codemod/cli.py
@@ -18,7 +18,7 @@ from django_codemod.commands import BaseCodemodCommand
 from django_codemod.visitors.base import BaseDjCodemodTransformer
 
 
-def index_codemoders(version_getter: Callable) -> Dict[Tuple[int, int], List]:
+def index_codemodders(version_getter: Callable) -> Dict[Tuple[int, int], List]:
     """
     Index codemodders by version.
 
@@ -44,8 +44,8 @@ def iter_codemodders() -> Generator[BaseDjCodemodTransformer, None, None]:
             continue
 
 
-DEPRECATED_IN = index_codemoders(version_getter=attrgetter("deprecated_in"))
-REMOVED_IN = index_codemoders(version_getter=attrgetter("removed_in"))
+DEPRECATED_IN = index_codemodders(version_getter=attrgetter("deprecated_in"))
+REMOVED_IN = index_codemodders(version_getter=attrgetter("removed_in"))
 
 
 class VersionParamType(click.ParamType):

--- a/django_codemod/cli.py
+++ b/django_codemod/cli.py
@@ -36,10 +36,8 @@ def iter_codemodders() -> Generator[BaseDjCodemodTransformer, None, None]:
     for object_name in dir(visitors):
         try:
             obj = getattr(visitors, object_name)
-            if not issubclass(obj, BaseDjCodemodTransformer) or inspect.isabstract(obj):
-                continue
-            # Looks like this one is good to go
-            yield obj
+            if issubclass(obj, BaseDjCodemodTransformer) and not inspect.isabstract(obj):
+                yield obj  # Looks like this one is good to go
         except TypeError:
             continue
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,12 +86,25 @@ def test_invalid_version(cli_runner):
     assert "'not.a.version' is not a valid version" in result.output
 
 
+def test_run_help(cli_runner):
+    result = cli_runner.invoke(
+        cli.djcodemod,
+        ["run", "--help"],
+    )
+
+    assert result.exit_code == 0
+    assert "--codemod" in result.output
+    assert "--deprecated-in" in result.output
+    assert "--removed-in" in result.output
+    assert "djcodemod list" in result.output
+
+
 @pytest.mark.parametrize(
     ("option", "version"),
     [
-        # Removed in option
         ("--removed-in", "3.0"),
         ("--deprecated-in", "2.0"),
+        ("--codemod", "URLResolversTransformer"),
     ],
 )
 @pytest.mark.parametrize("path", [".", "my_app"])


### PR DESCRIPTION
Fixes #207. 

```
$ djcodemod run --help
Usage: djcodemod run [OPTIONS] PATH...

  Automatically fixes deprecations removed Django deprecations.

  This command takes the path to target as argument and a version of Django
  to select code modifications to apply.

Options:
  --removed-in VERSION            The version of Django where feature are
                                  removed.

  --deprecated-in VERSION         The version of Django where deprecations
                                  started.

  --codemod (see `djcodemod list`)
                                  Choose a specific codemod to run. Can be
                                  repeated.

  --help                          Show this message and exit.
```