### PR TITLE
fix: don't confuse kwargs with symbol to codemod

### DIFF
--- a/tests/visitors/test_base.py
+++ b/tests/visitors/test_base.py
@@ -219,6 +219,22 @@ class TestFuncRenameTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
+    def test_kwargs(self) -> None:
+        """When function is called with a kwargs bearing the same name."""
+        before = """
+            from django.dummy.module import func
+
+            func()
+            something(func="test")
+        """
+        after = """
+            from django.dummy.module import better_func
+
+            better_func()
+            something(func="test")
+        """
+        self.assertCodemod(before, after)
+
 
 class OtherModuleFuncRenameTransformer(BaseFuncRenameTransformer):
     """Transformer with different module."""


### PR DESCRIPTION
Similar to #306, codemodders might wrongly replace a kwargs with the same name as the imported function.

Changed the fix for attributes access to work with both cases. The previous fix was slowing down the codemodding process a lot, this version should provide a nice speed up.