### PR TITLE
fix: error with star import

### DIFF
--- a/django_codemod/visitors/base.py
+++ b/django_codemod/visitors/base.py
@@ -70,8 +70,10 @@ class BaseRenameTransformer(BaseDjCodemodTransformer, ABC):
         self, original_node: ImportFrom, updated_node: ImportFrom
     ) -> Union[BaseSmallStatement, RemovalSentinel]:
         """Update import statements for matching old module name."""
-        if not import_from_matches(updated_node, self.old_module_parts):
-            return super().leave_ImportFrom(original_node, updated_node)
+        if not import_from_matches(updated_node, self.old_module_parts) or isinstance(
+            updated_node.names, ImportStar
+        ):
+            return updated_node
         # This is a match
         new_names = list(self.gen_new_imported_names(updated_node.names))
         self.save_import_scope(original_node)

--- a/tests/visitors/test_base.py
+++ b/tests/visitors/test_base.py
@@ -102,6 +102,20 @@ class TestFuncRenameTransformer(BaseVisitorTest):
         """
         self.assertCodemod(before, after)
 
+    def test_import_star_ignored(self) -> None:
+        """Should not change anything in case of a star import."""
+        before = """
+            from django.dummy.module import *
+
+            result = func()
+        """
+        after = """
+            from django.dummy.module import *
+
+            result = func()
+        """
+        self.assertCodemod(before, after)
+
     def test_same_name_function(self) -> None:
         """Should not be fooled by a function bearing the same name."""
         before = """


### PR DESCRIPTION
When the old module appears as star import, it crashes with:

```
for import_alias in old_names:
TypeError: 'ImportStar' object is not iterable
```

We could probably handle renaming in this case, but let's be conservative and only avoid the crash for now.