### PR TITLE
Fixes URLResolversTransformer so that it transforms urlresolvers

### DIFF
--- a/django_codemod/visitors/core.py
+++ b/django_codemod/visitors/core.py
@@ -1,8 +1,8 @@
 from django_codemod.constants import DJANGO_1_10, DJANGO_2_0
-from django_codemod.visitors.base import BaseModuleRenameTransformer
+from django_codemod.visitors.base import BaseFuncRenameTransformer
 
 
-class URLResolversTransformer(BaseModuleRenameTransformer):
+class URLResolversTransformer(BaseFuncRenameTransformer):
     """Replace `django.core.urlresolvers` by `django.urls`."""
 
     deprecated_in = DJANGO_1_10


### PR DESCRIPTION
This use-case was failing to transform: 
```
from django.core import serializers, urlresolvers
```

Until I updated to the `BaseFuncRenameTransformer` class. 