### PR TITLE
docs: fix link to changelog on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/browniebroke/django-codemod/issues"
-"Changelog" = "https://django-codemod.readthedocs.io/changelog.html"
+"Changelog" = "https://django-codemod.readthedocs.io/en/stable/changelog.html"
 
 [tool.poetry.scripts]
 djcodemod = "django_codemod.cli:djcodemod"


### PR DESCRIPTION
Link from [Pypi package](https://pypi.org/project/django-codemod/) to [CHANGELOG](https://django-codemod.readthedocs.io/changelog.html) is broken. It returns 404 page.