### PR TITLE
Handle removed compatibility imports in 3.1

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "body-max-line-length": [0, "always", Infinity],
+    "header-max-length": [0, "always", Infinity],
   },
 };

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -9,6 +9,7 @@ from .encoding import (
 )
 from .exceptions import (
     DatastructuresEmptyResultSetTransformer,
+    FieldDoesNotExistTransformer,
     QueryEmptyResultSetTransformer,
     SqlEmptyResultSetTransformer,
 )
@@ -55,6 +56,7 @@ __all__ = (
     "ContextDecoratorTransformer",
     "CookieDateTransformer",
     "DatastructuresEmptyResultSetTransformer",
+    "FieldDoesNotExistTransformer",
     "FixedOffsetTransformer",
     "FloatRangeFormFieldTransformer",
     "FloatRangeModelFieldTransformer",

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -39,6 +39,12 @@ from .postgres_fields import (
 )
 from .shortcuts import RenderToResponseTransformer
 from .signals import SignalDisconnectWeakTransformer
+from .template_context import (
+    BaseContextTransformer,
+    ContextPopExceptionTransformer,
+    ContextTransformer,
+    RequestContextTransformer,
+)
 from .template_tags import AssignmentTagTransformer
 from .timezone import FixedOffsetTransformer
 from .translations import (
@@ -54,8 +60,11 @@ __all__ = (
     "AbsPathTransformer",
     "AssignmentTagTransformer",
     "AvailableAttrsTransformer",
+    "BaseContextTransformer",
     "BoundFieldTransformer",
     "ContextDecoratorTransformer",
+    "ContextPopExceptionTransformer",
+    "ContextTransformer",
     "CookieDateTransformer",
     "DatastructuresEmptyResultSetTransformer",
     "FieldDoesNotExistTransformer",
@@ -76,9 +85,11 @@ __all__ = (
     "ModelsPermalinkTransformer",
     "NullBooleanFieldTransformer",
     "OnDeleteTransformer",
+    "PrettyNameTransformer",
     "QueryEmptyResultSetTransformer",
     "QuerySetPaginatorTransformer",
     "RenderToResponseTransformer",
+    "RequestContextTransformer",
     "SignalDisconnectWeakTransformer",
     "SmartTextTransformer",
     "SqlEmptyResultSetTransformer",
@@ -91,5 +102,4 @@ __all__ = (
     "URLTransformer",
     "UnescapeEntitiesTransformer",
     "UnicodeCompatibleTransformer",
-    "PrettyNameTransformer",
 )

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     QueryEmptyResultSetTransformer,
     SqlEmptyResultSetTransformer,
 )
+from .forms import PrettyNameTransformer
 from .html import UnescapeEntitiesTransformer
 from .http import (
     CookieDateTransformer,
@@ -89,4 +90,5 @@ __all__ = (
     "URLTransformer",
     "UnescapeEntitiesTransformer",
     "UnicodeCompatibleTransformer",
+    "PrettyNameTransformer",
 )

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
     QueryEmptyResultSetTransformer,
     SqlEmptyResultSetTransformer,
 )
-from .forms import PrettyNameTransformer
+from .forms import BoundFieldTransformer, PrettyNameTransformer
 from .html import UnescapeEntitiesTransformer
 from .http import (
     CookieDateTransformer,
@@ -54,6 +54,7 @@ __all__ = (
     "AbsPathTransformer",
     "AssignmentTagTransformer",
     "AvailableAttrsTransformer",
+    "BoundFieldTransformer",
     "ContextDecoratorTransformer",
     "CookieDateTransformer",
     "DatastructuresEmptyResultSetTransformer",

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -7,6 +7,11 @@ from .encoding import (
     SmartTextTransformer,
     UnicodeCompatibleTransformer,
 )
+from .exceptions import (
+    DatastructuresEmptyResultSetTransformer,
+    QueryEmptyResultSetTransformer,
+    SqlEmptyResultSetTransformer,
+)
 from .html import UnescapeEntitiesTransformer
 from .http import (
     CookieDateTransformer,
@@ -49,6 +54,7 @@ __all__ = (
     "AvailableAttrsTransformer",
     "ContextDecoratorTransformer",
     "CookieDateTransformer",
+    "DatastructuresEmptyResultSetTransformer",
     "FixedOffsetTransformer",
     "FloatRangeFormFieldTransformer",
     "FloatRangeModelFieldTransformer",
@@ -66,17 +72,19 @@ __all__ = (
     "ModelsPermalinkTransformer",
     "NullBooleanFieldTransformer",
     "OnDeleteTransformer",
+    "QueryEmptyResultSetTransformer",
     "QuerySetPaginatorTransformer",
     "RenderToResponseTransformer",
     "SignalDisconnectWeakTransformer",
     "SmartTextTransformer",
+    "SqlEmptyResultSetTransformer",
     "UGetTextLazyTransformer",
     "UGetTextNoopTransformer",
     "UGetTextTransformer",
-    "UnescapeEntitiesTransformer",
     "UNGetTextLazyTransformer",
     "UNGetTextTransformer",
-    "UnicodeCompatibleTransformer",
     "URLResolversTransformer",
     "URLTransformer",
+    "UnescapeEntitiesTransformer",
+    "UnicodeCompatibleTransformer",
 )

--- a/django_codemod/visitors/__init__.py
+++ b/django_codemod/visitors/__init__.py
@@ -1,4 +1,4 @@
-from .admin import InlineHasAddPermissionsTransformer
+from .admin import ActionCheckboxNameTransformer, InlineHasAddPermissionsTransformer
 from .core import URLResolversTransformer
 from .crypto import GetRandomStringTransformer
 from .decorators import AvailableAttrsTransformer, ContextDecoratorTransformer
@@ -58,6 +58,7 @@ from .urls import URLTransformer
 
 __all__ = (
     "AbsPathTransformer",
+    "ActionCheckboxNameTransformer",
     "AssignmentTagTransformer",
     "AvailableAttrsTransformer",
     "BaseContextTransformer",

--- a/django_codemod/visitors/admin.py
+++ b/django_codemod/visitors/admin.py
@@ -15,9 +15,13 @@ from libcst import (
 )
 from libcst import matchers as m
 
-from django_codemod.constants import DJANGO_2_1, DJANGO_3_0
+from django_codemod.constants import DJANGO_1_3, DJANGO_2_1, DJANGO_3_0, DJANGO_3_1
 from django_codemod.utils.calls import parse_arg, parse_param
-from django_codemod.visitors.base import BaseDjCodemodTransformer, module_matcher
+from django_codemod.visitors.base import (
+    BaseDjCodemodTransformer,
+    BaseRenameTransformer,
+    module_matcher,
+)
 
 
 class InlineHasAddPermissionsTransformer(BaseDjCodemodTransformer):
@@ -143,3 +147,12 @@ class InlineHasAddPermissionsTransformer(BaseDjCodemodTransformer):
             )
             return updated_node.with_changes(args=updated_args)
         return super().leave_Call(original_node, updated_node)
+
+
+class ActionCheckboxNameTransformer(BaseRenameTransformer):
+    """Replace `django.contrib.admin.ACTION_CHECKBOX_NAME` compatibility import"""
+
+    deprecated_in = DJANGO_1_3
+    removed_in = DJANGO_3_1
+    rename_from = "django.contrib.admin.ACTION_CHECKBOX_NAME"
+    rename_to = "django.contrib.admin.helpers.ACTION_CHECKBOX_NAME"

--- a/django_codemod/visitors/exceptions.py
+++ b/django_codemod/visitors/exceptions.py
@@ -1,0 +1,32 @@
+from django_codemod.constants import DJANGO_1_11, DJANGO_3_1
+from django_codemod.visitors.base import BaseRenameTransformer
+
+
+class QueryEmptyResultSetTransformer(BaseRenameTransformer):
+    """Replace `django.db.models.query.EmptyResultSet` compatibility import."""
+
+    deprecated_in = DJANGO_1_11
+    removed_in = DJANGO_3_1
+    rename_from = "django.db.models.query.EmptyResultSet"
+    rename_to = "django.core.exceptions.EmptyResultSet"
+
+
+class SqlEmptyResultSetTransformer(BaseRenameTransformer):
+    """Replace `django.db.models.sql.EmptyResultSet` compatibility import."""
+
+    deprecated_in = DJANGO_1_11
+    removed_in = DJANGO_3_1
+    rename_from = "django.db.models.sql.EmptyResultSet"
+    rename_to = "django.core.exceptions.EmptyResultSet"
+
+
+class DatastructuresEmptyResultSetTransformer(BaseRenameTransformer):
+    """
+    Replace `django.db.models.sql.datastructures.EmptyResultSet` compatibility
+    import.
+    """
+
+    deprecated_in = DJANGO_1_11
+    removed_in = DJANGO_3_1
+    rename_from = "django.db.models.sql.datastructures.EmptyResultSet"
+    rename_to = "django.core.exceptions.EmptyResultSet"

--- a/django_codemod/visitors/exceptions.py
+++ b/django_codemod/visitors/exceptions.py
@@ -1,4 +1,4 @@
-from django_codemod.constants import DJANGO_1_11, DJANGO_3_1
+from django_codemod.constants import DJANGO_1_8, DJANGO_1_11, DJANGO_3_1
 from django_codemod.visitors.base import BaseRenameTransformer
 
 
@@ -30,3 +30,12 @@ class DatastructuresEmptyResultSetTransformer(BaseRenameTransformer):
     removed_in = DJANGO_3_1
     rename_from = "django.db.models.sql.datastructures.EmptyResultSet"
     rename_to = "django.core.exceptions.EmptyResultSet"
+
+
+class FieldDoesNotExistTransformer(BaseRenameTransformer):
+    """Replace `django.db.models.fields.FieldDoesNotExist` compatibility import."""
+
+    deprecated_in = DJANGO_1_8
+    removed_in = DJANGO_3_1
+    rename_from = "django.db.models.fields.FieldDoesNotExist"
+    rename_to = "django.core.exceptions.FieldDoesNotExist"

--- a/django_codemod/visitors/forms.py
+++ b/django_codemod/visitors/forms.py
@@ -1,0 +1,11 @@
+from django_codemod.constants import DJANGO_1_9, DJANGO_3_1
+from django_codemod.visitors.base import BaseRenameTransformer
+
+
+class PrettyNameTransformer(BaseRenameTransformer):
+    """Replace `django.forms.forms.pretty_name` compatibility import."""
+
+    deprecated_in = DJANGO_1_9
+    removed_in = DJANGO_3_1
+    rename_from = "django.forms.forms.pretty_name"
+    rename_to = "django.forms.utils.pretty_name"

--- a/django_codemod/visitors/forms.py
+++ b/django_codemod/visitors/forms.py
@@ -9,3 +9,12 @@ class PrettyNameTransformer(BaseRenameTransformer):
     removed_in = DJANGO_3_1
     rename_from = "django.forms.forms.pretty_name"
     rename_to = "django.forms.utils.pretty_name"
+
+
+class BoundFieldTransformer(BaseRenameTransformer):
+    """Replace `django.forms.forms.BoundField` compatibility import."""
+
+    deprecated_in = DJANGO_1_9
+    removed_in = DJANGO_3_1
+    rename_from = "django.forms.forms.BoundField"
+    rename_to = "django.forms.boundfield.BoundField"

--- a/django_codemod/visitors/template_context.py
+++ b/django_codemod/visitors/template_context.py
@@ -1,0 +1,38 @@
+from django_codemod.constants import DJANGO_1_7, DJANGO_3_1
+from django_codemod.visitors.base import BaseRenameTransformer
+
+
+class BaseContextTransformer(BaseRenameTransformer):
+    """Replace `django.template.base.BaseContext` compatibility import."""
+
+    deprecated_in = DJANGO_1_7
+    removed_in = DJANGO_3_1
+    rename_from = "django.template.base.BaseContext"
+    rename_to = "django.template.context.BaseContext"
+
+
+class ContextTransformer(BaseRenameTransformer):
+    """Replace `django.template.base.Context` compatibility import."""
+
+    deprecated_in = DJANGO_1_7
+    removed_in = DJANGO_3_1
+    rename_from = "django.template.base.Context"
+    rename_to = "django.template.context.Context"
+
+
+class RequestContextTransformer(BaseRenameTransformer):
+    """Replace `django.template.base.RequestContext` compatibility import."""
+
+    deprecated_in = DJANGO_1_7
+    removed_in = DJANGO_3_1
+    rename_from = "django.template.base.RequestContext"
+    rename_to = "django.template.context.RequestContext"
+
+
+class ContextPopExceptionTransformer(BaseRenameTransformer):
+    """Replace `django.template.base.ContextPopException` compatibility import."""
+
+    deprecated_in = DJANGO_1_7
+    removed_in = DJANGO_3_1
+    rename_from = "django.template.base.ContextPopException"
+    rename_to = "django.template.context.ContextPopException"

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -75,6 +75,12 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.11` option:
   in `django.db.models.query`, `django.db.models.sql`, and
   `django.db.models.sql.datastructures` by an import from `django.core.exceptions`.
 
+Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.8` option:
+
+- Replace compatibility imports of `FieldDoesNotExist`
+  in `django.db.models.fields` by an import from
+  `django.core.exceptions`.
+
 ## Removed in Django 4.0
 
 Applied by passing the `--removed-in 4.0` or `--deprecated-in 3.0` option:

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -73,13 +73,17 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.11` option:
 
 - Replace compatibility imports of `EmptyResultSet`
   in `django.db.models.query`, `django.db.models.sql`, and
-  `django.db.models.sql.datastructures` by an import from `django.core.exceptions`.
+  `django.db.models.sql.datastructures` by import from `django.core.exceptions`.
+
+Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.9` option:
+
+- Replace compatibility imports of `pretty_name`
+  in `django.forms.forms` by import from `django.forms.utils`.
 
 Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.8` option:
 
 - Replace compatibility imports of `FieldDoesNotExist`
-  in `django.db.models.fields` by an import from
-  `django.core.exceptions`.
+  in `django.db.models.fields` by import from `django.core.exceptions`.
 
 ## Removed in Django 4.0
 

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -87,6 +87,12 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.8` option:
 - Replace compatibility imports of `FieldDoesNotExist`
   in `django.db.models.fields` by import from `django.core.exceptions`.
 
+Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.7` option:
+
+- Replace compatibility imports of `BaseContext`, `Context`,
+  `ContextPopException` and `RequestContext` in `django.template.base`
+  by import from `django.template.context`.
+
 ## Removed in Django 4.0
 
 Applied by passing the `--removed-in 4.0` or `--deprecated-in 3.0` option:

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -93,6 +93,11 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.7` option:
   `ContextPopException` and `RequestContext` in `django.template.base`
   by import from `django.template.context`.
 
+Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.3` option:
+
+- Replace compatibility imports of `ACTION_CHECKBOX_NAME` in
+  `django.contrib.admin` by import from `django.contrib.admin.helpers`.
+
 ## Removed in Django 4.0
 
 Applied by passing the `--removed-in 4.0` or `--deprecated-in 3.0` option:

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -79,6 +79,8 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.9` option:
 
 - Replace compatibility imports of `pretty_name`
   in `django.forms.forms` by import from `django.forms.utils`.
+- Replace compatibility imports of `BoundField`
+  in `django.forms.forms` by import from `django.forms.boundfield`.
 
 Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.8` option:
 

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -69,6 +69,12 @@ Applied by passing the `--removed-in 3.1` or `--deprecated-in 2.2` option:
 - Replace the `FloatRangeField` model and form fields in
   `django.contrib.postgres` by `DecimalRangeField`.
 
+Applied by passing the `--removed-in 3.1` or `--deprecated-in 1.11` option:
+
+- Replace compatibility imports of `EmptyResultSet`
+  in `django.db.models.query`, `django.db.models.sql`, and
+  `django.db.models.sql.datastructures` by an import from `django.core.exceptions`.
+
 ## Removed in Django 4.0
 
 Applied by passing the `--removed-in 4.0` or `--deprecated-in 3.0` option:

--- a/tests/visitors/test_admin.py
+++ b/tests/visitors/test_admin.py
@@ -1,6 +1,9 @@
 from parameterized import parameterized
 
-from django_codemod.visitors import InlineHasAddPermissionsTransformer
+from django_codemod.visitors import (
+    ActionCheckboxNameTransformer,
+    InlineHasAddPermissionsTransformer,
+)
 from tests.visitors.base import BaseVisitorTest
 
 
@@ -192,5 +195,19 @@ class TestInlineHasAddPermissionsTransformer(BaseVisitorTest):
 
                 def has_add_permission(self, request):
                     return False
+        """
+        self.assertCodemod(before, after)
+
+
+class TestActionCheckboxNameTransformer(BaseVisitorTest):
+
+    transformer = ActionCheckboxNameTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.contrib.admin import ACTION_CHECKBOX_NAME
+        """
+        after = """
+            from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
         """
         self.assertCodemod(before, after)

--- a/tests/visitors/test_exceptions.py
+++ b/tests/visitors/test_exceptions.py
@@ -1,0 +1,60 @@
+from django_codemod.visitors import (
+    DatastructuresEmptyResultSetTransformer,
+    QueryEmptyResultSetTransformer,
+    SqlEmptyResultSetTransformer,
+)
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestQueryEmptyResultSetTransformer(BaseVisitorTest):
+
+    transformer = QueryEmptyResultSetTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.db.models.query import EmptyResultSet
+
+            EmptyResultSet()
+        """
+        after = """
+            from django.core.exceptions import EmptyResultSet
+
+            EmptyResultSet()
+        """
+        self.assertCodemod(before, after)
+
+
+class TestSqlEmptyResultSetTransformer(BaseVisitorTest):
+
+    transformer = SqlEmptyResultSetTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.db.models.sql import EmptyResultSet
+
+            EmptyResultSet()
+        """
+        after = """
+            from django.core.exceptions import EmptyResultSet
+
+            EmptyResultSet()
+        """
+        self.assertCodemod(before, after)
+
+
+class TestDatastructuresEmptyResultSetTransformer(BaseVisitorTest):
+
+    transformer = DatastructuresEmptyResultSetTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.db.models.sql.datastructures import EmptyResultSet
+
+            EmptyResultSet()
+        """
+        after = """
+            from django.core.exceptions import EmptyResultSet
+
+            EmptyResultSet()
+        """
+        self.assertCodemod(before, after)

--- a/tests/visitors/test_exceptions.py
+++ b/tests/visitors/test_exceptions.py
@@ -1,5 +1,6 @@
 from django_codemod.visitors import (
     DatastructuresEmptyResultSetTransformer,
+    FieldDoesNotExistTransformer,
     QueryEmptyResultSetTransformer,
     SqlEmptyResultSetTransformer,
 )
@@ -56,5 +57,23 @@ class TestDatastructuresEmptyResultSetTransformer(BaseVisitorTest):
             from django.core.exceptions import EmptyResultSet
 
             EmptyResultSet()
+        """
+        self.assertCodemod(before, after)
+
+
+class TestFieldDoesNotExistTransformer(BaseVisitorTest):
+
+    transformer = FieldDoesNotExistTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.db.models.fields import FieldDoesNotExist
+
+            FieldDoesNotExist()
+        """
+        after = """
+            from django.core.exceptions import FieldDoesNotExist
+
+            FieldDoesNotExist()
         """
         self.assertCodemod(before, after)

--- a/tests/visitors/test_forms.py
+++ b/tests/visitors/test_forms.py
@@ -1,0 +1,20 @@
+from django_codemod.visitors import PrettyNameTransformer
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestPrettyNameTransformer(BaseVisitorTest):
+
+    transformer = PrettyNameTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.forms.forms import pretty_name
+
+            pretty_name()
+        """
+        after = """
+            from django.forms.utils import pretty_name
+
+            pretty_name()
+        """
+        self.assertCodemod(before, after)

--- a/tests/visitors/test_forms.py
+++ b/tests/visitors/test_forms.py
@@ -1,4 +1,4 @@
-from django_codemod.visitors import PrettyNameTransformer
+from django_codemod.visitors import BoundFieldTransformer, PrettyNameTransformer
 from tests.visitors.base import BaseVisitorTest
 
 
@@ -16,5 +16,23 @@ class TestPrettyNameTransformer(BaseVisitorTest):
             from django.forms.utils import pretty_name
 
             pretty_name()
+        """
+        self.assertCodemod(before, after)
+
+
+class TestBoundFieldTransformer(BaseVisitorTest):
+
+    transformer = BoundFieldTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.forms.forms import BoundField
+
+            BoundField()
+        """
+        after = """
+            from django.forms.boundfield import BoundField
+
+            BoundField()
         """
         self.assertCodemod(before, after)

--- a/tests/visitors/test_template_context.py
+++ b/tests/visitors/test_template_context.py
@@ -1,0 +1,79 @@
+from django_codemod.visitors import (
+    BaseContextTransformer,
+    ContextPopExceptionTransformer,
+    ContextTransformer,
+    RequestContextTransformer,
+)
+from tests.visitors.base import BaseVisitorTest
+
+
+class TestBaseContextTransformer(BaseVisitorTest):
+
+    transformer = BaseContextTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.template.base import BaseContext
+
+            BaseContext({})
+        """
+        after = """
+            from django.template.context import BaseContext
+
+            BaseContext({})
+        """
+        self.assertCodemod(before, after)
+
+
+class TestContextTransformer(BaseVisitorTest):
+
+    transformer = ContextTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.template.base import Context
+
+            Context({})
+        """
+        after = """
+            from django.template.context import Context
+
+            Context({})
+        """
+        self.assertCodemod(before, after)
+
+
+class TestRequestContextTransformer(BaseVisitorTest):
+
+    transformer = RequestContextTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.template.base import RequestContext
+
+            RequestContext({})
+        """
+        after = """
+            from django.template.context import RequestContext
+
+            RequestContext({})
+        """
+        self.assertCodemod(before, after)
+
+
+class TestContextPopExceptionTransformer(BaseVisitorTest):
+
+    transformer = ContextPopExceptionTransformer
+
+    def test_simple_substitution(self) -> None:
+        before = """
+            from django.template.base import ContextPopException
+
+            raise ContextPopException()
+        """
+        after = """
+            from django.template.context import ContextPopException
+
+            raise ContextPopException()
+        """
+        self.assertCodemod(before, after)


### PR DESCRIPTION
- [x] `django.core.exceptions.EmptyResultSet`
- [x] `django.core.exceptions.FieldDoesNotExist`
- [x] `django.forms.utils.pretty_name`
- [x] `django.forms.boundfield.BoundField`
- [x] `Context`
- [x] `ContextPopException`
- [x] `RequestContext`
- [x] `django.contrib.admin.helpers.ACTION_CHECKBOX_NAME`

Fix #446 