### PR TITLE
chore: upgrade to latest pyupgrade

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -833,7 +833,7 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4cf130adeecc437ee8f9d11d383a5a136068d04af3fe3bf5965991412bb49e6d"
+content-hash = "5e7457cf684af47f07f7a685e7aaf081f8cb59a7c50d63fc36fadced889962aa"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pytest-mock = "^3.3.1"
 tox = "^3.20.1"
 parameterized = "^0.8.0"
 flake8 = "^4.0.0"
-pyupgrade = "^2.29"
+pyupgrade = "^2.31"
 isort = "^5.10"
 mypy = "^0.931"
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos