### PR TITLE
chore: drop patch version for all stable dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -834,7 +834,7 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9e3ac331300e5f93f15500282e8208775ce1ba475fc53922e643a44dd6d480b6"
+content-hash = "40ed3cde142b1bf2ed2e6bcb0c1c719f7caec20b532e8e45c3178ec48a05f485"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,13 @@ docs = [
 ]
 
 [tool.poetry.dev-dependencies]
-pytest = "^7.0.0"
+pytest = "^7.0"
 black = "^22.1"
-pytest-cov = "^3.0.0"
-pytest-mock = "^3.3.1"
-tox = "^3.20.1"
+pytest-cov = "^3.0"
+pytest-mock = "^3.3"
+tox = "^3.20"
 parameterized = "^0.8.0"
-flake8 = "^4.0.0"
+flake8 = "^4.0"
 pyupgrade = "^2.31"
 isort = "^5.10"
 mypy = "^0.931"


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos