### PR TITLE
chore: drop patch version for all stable dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -834,7 +834,7 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "40ed3cde142b1bf2ed2e6bcb0c1c719f7caec20b532e8e45c3178ec48a05f485"
+content-hash = "38c83c7fd0070724682972f035b7752e3b2c4c36171b2ecb82e4e16833496742"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ pathspec = ">=0.6,<1"
 rich = "<12"
 
 # Docs deps
-Sphinx = {version = "^4.0.0", optional = true}
-sphinx-rtd-theme = {version = "^1.0.0", optional = true}
-myst-parser = {version = "^0.17.0", optional = true}
+Sphinx = { version = "^4.0", optional = true }
+sphinx-rtd-theme = { version = "^1.0", optional = true }
+myst-parser = { version = "^0.17.0", optional = true }
 
 [tool.poetry.extras]
 docs = [


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos