### PR TITLE
feat: drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     rev: v3.7.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ packages = [
 djcodemod = "django_codemod.cli:djcodemod"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 click = "<9"
 libcst = "==1.0.1"
 pathspec = ">=0.6,<1"


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Python 3.7 as it reached EOL on June 27, 2023. More infos: https://devguide.python.org/versions/

Committed via https://github.com/asottile/all-repos