### PR TITLE
chore: attest build provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Attest build build provenance
+      - name: Attest build provenance
         uses: actions/attest-build-provenance@v1
         if: steps.release.outputs.released == 'true'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
     concurrency: release
     permissions:
       id-token: write
+      attestations: write
       contents: write
 
     steps:
@@ -106,6 +107,12 @@ jobs:
         if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build build provenance
+        uses: actions/attest-build-provenance@v1
+        if: steps.release.outputs.released == 'true'
+        with:
+          subject-path: "dist/*"
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update CI workflow to include a step for attesting build provenance when a release is successful.

CI:
- Add step to attest build provenance using actions/attest-build-provenance@v1 if the release is successful.

<!-- Generated by sourcery-ai[bot]: end summary -->