### PR TITLE
chore: add pyproject-fmt to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,10 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: "2.2.3"
+    hooks:
+      - id: pyproject-fmt
   - repo: https://github.com/python-poetry/poetry
     rev: 1.8.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,28 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = [ "poetry-core>=1" ]
+
 [tool.poetry]
 name = "django-codemod"
 version = "2.1.11"
 description = "A command line tool to automatically fix Django deprecations."
-authors = ["Bruno Alla <alla.brunoo@gmail.com>"]
+authors = [ "Bruno Alla <alla.brunoo@gmail.com>" ]
 license = "MIT"
 readme = "README.md"
-keywords = ["django", "codemod", "libCST"]
+keywords = [ "django", "codemod", "libCST" ]
 repository = "https://github.com/browniebroke/django-codemod"
 documentation = "https://django-codemod.readthedocs.io"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.12",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Topic :: Software Development :: Libraries",
+  "Programming Language :: Python :: 3.12",
 ]
 packages = [
-    { include = "django_codemod", from = "src" },
-    { include = "tests", format = "sdist" },
+  { include = "django_codemod", from = "src" },
+  { include = "tests", format = "sdist" },
 ]
 
 [tool.poetry.urls]
@@ -52,85 +56,56 @@ myst-parser = { version = ">=0.16", python = ">=3.11" }
 sphinx = { version = ">=4.0", python = ">=3.11" }
 furo = { version = ">=2023.5.20", python = ">=3.11" }
 
-[tool.semantic_release]
-version_toml = ["pyproject.toml:tool.poetry.version"]
-version_variables = [
-    "src/django_codemod/__init__.py:__version__",
-]
-build_command = "pip install poetry && poetry build"
-
-[tool.semantic_release.changelog]
-exclude_commit_patterns = [
-    "chore.*",
-    "ci.*",
-    "Merge pull request .*",
-]
-
-[tool.semantic_release.changelog.environment]
-keep_trailing_newline = true
-
-[tool.semantic_release.branches.main]
-match = "main"
-
-[tool.semantic_release.branches.noop]
-match = "(?!main$)"
-prerelease = true
-
-[tool.pytest.ini_options]
-addopts = "-v -Wdefault --cov=django_codemod --cov-report=term-missing:skip-covered"
-pythonpath = ["src"]
-
 [tool.ruff]
 target-version = "py38"
 line-length = 88
 
-[tool.ruff.lint]
-ignore = [
-    "D203", # 1 blank line required before class docstring
-    "D212", # Multi-line docstring summary should start at the first line
-    "D100", # Missing docstring in public module
-    "D101", # Missing docstring in public class
-    "D102", # Missing docstring in public method
-    "D104", # Missing docstring in public package
-    "D107", # Missing docstring in `__init__`
-    "D401", # First line of docstring should be in imperative mood
+lint.select = [
+  "B",   # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "D",   # flake8-docstrings
+  "E",   # pycodestyle
+  "F",   # pyflake
+  "I",   # isort
+  "RUF", # ruff specific
+  "S",   # flake8-bandit
+  "UP",  # pyupgrade
+  "W",   # pycodestyle
 ]
-select = [
-    "B",   # flake8-bugbear
-    "D",   # flake8-docstrings
-    "C4",  # flake8-comprehensions
-    "S",   # flake8-bandit
-    "F",   # pyflake
-    "E",   # pycodestyle
-    "W",   # pycodestyle
-    "UP",  # pyupgrade
-    "I",   # isort
-    "RUF", # ruff specific
+lint.ignore = [
+  "D100", # Missing docstring in public module
+  "D101", # Missing docstring in public class
+  "D102", # Missing docstring in public method
+  "D104", # Missing docstring in public package
+  "D107", # Missing docstring in `__init__`
+  "D203", # 1 blank line required before class docstring
+  "D212", # Multi-line docstring summary should start at the first line
+  "D401", # First line of docstring should be in imperative mood
 ]
+lint.per-file-ignores."conftest.py" = [ "D100" ]
+lint.per-file-ignores."docs/conf.py" = [ "D100" ]
+lint.per-file-ignores."tests/**/*" = [
+  "D100",
+  "D101",
+  "D102",
+  "D103",
+  "D104",
+  "S101",
+]
+lint.isort.known-first-party = [ "django_codemod", "tests" ]
 
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*" = [
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "S101",
-]
-"conftest.py" = ["D100"]
-"docs/conf.py" = ["D100"]
-
-[tool.ruff.lint.isort]
-known-first-party = ["django_codemod", "tests"]
+[tool.pytest.ini_options]
+addopts = "-v -Wdefault --cov=django_codemod --cov-report=term-missing:skip-covered"
+pythonpath = [ "src" ]
 
 [tool.coverage.run]
 branch = true
 
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: no cover",
-    "raise AssertionError",
-    "raise NotImplementedError",
+  "pragma: no cover",
+  "raise AssertionError",
+  "raise NotImplementedError",
 ]
 
 [tool.mypy]
@@ -144,6 +119,26 @@ warn_no_return = true
 
 show_error_codes = true
 
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.semantic_release]
+version_toml = [ "pyproject.toml:tool.poetry.version" ]
+version_variables = [
+  "src/django_codemod/__init__.py:__version__",
+]
+build_command = "pip install poetry && poetry build"
+
+[tool.semantic_release.changelog]
+exclude_commit_patterns = [
+  "chore.*",
+  "ci.*",
+  "Merge pull request .*",
+]
+
+[tool.semantic_release.changelog.environment]
+keep_trailing_newline = true
+
+[tool.semantic_release.branches.main]
+match = "main"
+
+[tool.semantic_release.branches.noop]
+match = "(?!main$)"
+prerelease = true


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Integrate pyproject-fmt into the pre-commit configuration to automate the formatting of pyproject.toml files.

Chores:
- Add pyproject-fmt to the pre-commit configuration to ensure consistent formatting of pyproject.toml files.

<!-- Generated by sourcery-ai[bot]: end summary -->