### PR TITLE
feat: drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1038,5 +1038,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "50c3a2ff1ee9ea9a0fad621661da49d98c8ac35b35e208fe1cc358041e506639"
+python-versions = "^3.9"
+content-hash = "6b4db6a31c864a5954ba2ca7a91f502c08da241e9937e79e6fee1fe79c2c5c4b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ packages = [
 djcodemod = "django_codemod.cli:djcodemod"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 click = "<9"
 libcst = "==1.1.0"
 pathspec = ">=0.6,<1"
@@ -57,7 +57,7 @@ sphinx = { version = ">=4.0", python = ">=3.11" }
 furo = { version = ">=2023.5.20", python = ">=3.11" }
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 88
 
 lint.select = [

--- a/src/django_codemod/cli.py
+++ b/src/django_codemod/cli.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import Generator
 from operator import attrgetter
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Type
+from typing import Callable, Optional
 
 import rich_click as click
 from libcst.codemod import CodemodContext, parallel_exec_transform_with_prettyprint
@@ -17,7 +17,7 @@ from django_codemod.path_utils import get_sources
 from django_codemod.visitors.base import BaseDjCodemodTransformer
 
 
-def index_codemodders(version_getter: Callable) -> Dict[Tuple[int, int], List]:
+def index_codemodders(version_getter: Callable) -> dict[tuple[int, int], list]:
     """
     Index codemodders by version.
 
@@ -30,7 +30,7 @@ def index_codemodders(version_getter: Callable) -> Dict[Tuple[int, int], List]:
     return dict(codemodders_index)
 
 
-def iter_codemodders() -> Generator[Type[BaseDjCodemodTransformer], None, None]:
+def iter_codemodders() -> Generator[type[BaseDjCodemodTransformer], None, None]:
     """Iterator of all the codemodders classes."""
     for object_name in dir(visitors):
         try:
@@ -62,15 +62,15 @@ class VersionParamType(click.ParamType):
         " e.g. '2.2' or '2.2.10'"
     )
 
-    def __init__(self, version_index: Dict[Tuple[int, int], List]) -> None:
-        self.valid_versions: List[Tuple[int, int]] = list(version_index.keys())
+    def __init__(self, version_index: dict[tuple[int, int], list]) -> None:
+        self.valid_versions: list[tuple[int, int]] = list(version_index.keys())
 
     def convert(  # type: ignore[return]
         self,
         value: str,
         param: Optional[click.Parameter],
         ctx: Optional[click.Context],
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Parse version to keep only major an minor digits."""
         try:
             return self._parse_unsafe(value, param, ctx)
@@ -86,7 +86,7 @@ class VersionParamType(click.ParamType):
         value: str,
         param: Optional[click.Parameter],
         ctx: Optional[click.Context],
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Parse version and validate it's a supported one."""
         parsed_version = self._split_digits(value, param, ctx)
         if parsed_version not in self.valid_versions:
@@ -107,7 +107,7 @@ class VersionParamType(click.ParamType):
         value: str,
         param: Optional[click.Parameter],
         ctx: Optional[click.Context],
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Split version into 2-tuple of digits, ignoring patch digit."""
         values_parts = tuple(int(v) for v in value.split("."))
         if len(values_parts) < 2:
@@ -156,10 +156,10 @@ def djcodemod():
     multiple=True,
 )
 def run(
-    removed_in: List[Tuple[int, int]],
-    deprecated_in: List[Tuple[int, int]],
-    codemod: List[str],
-    src: Tuple[str, ...],
+    removed_in: list[tuple[int, int]],
+    deprecated_in: list[tuple[int, int]],
+    codemod: list[str],
+    src: tuple[str, ...],
 ) -> None:
     """
     Automatically fixes deprecations removed Django deprecations.
@@ -186,7 +186,7 @@ def run(
     call_command(command_instance, files)
 
 
-def call_command(command_instance: BaseCodemodCommand, files: List[Path]):
+def call_command(command_instance: BaseCodemodCommand, files: list[Path]):
     """Call libCST with our customized command."""
     try:
         # Super simplified call
@@ -229,7 +229,7 @@ def list_() -> None:
     console.print(table)
 
 
-def generate_rows() -> Generator[Tuple[str, str, str, str], None, None]:
+def generate_rows() -> Generator[tuple[str, str, str, str], None, None]:
     """Build up the rows for the table of codemodders."""
     codemodders_list = sorted(
         iter_codemodders(), key=lambda obj: (obj.deprecated_in, obj.removed_in)
@@ -243,7 +243,7 @@ def generate_rows() -> Generator[Tuple[str, str, str, str], None, None]:
         )
 
 
-def get_short_description(codemodder: Type[BaseDjCodemodTransformer]) -> str:
+def get_short_description(codemodder: type[BaseDjCodemodTransformer]) -> str:
     """Get a one line description of the codemodder from its docstring."""
     if codemodder.__doc__ is None:
         return ""
@@ -253,6 +253,6 @@ def get_short_description(codemodder: Type[BaseDjCodemodTransformer]) -> str:
     return ""
 
 
-def version_str(version_parts: Tuple[int, int]) -> str:
+def version_str(version_parts: tuple[int, int]) -> str:
     """Format the version tuple as string."""
     return ".".join(str(d) for d in version_parts)

--- a/src/django_codemod/cli.py
+++ b/src/django_codemod/cli.py
@@ -1,8 +1,9 @@
 import inspect
 from collections import defaultdict
+from collections.abc import Generator
 from operator import attrgetter
 from pathlib import Path
-from typing import Callable, Dict, Generator, List, Optional, Tuple, Type
+from typing import Callable, Dict, List, Optional, Tuple, Type
 
 import rich_click as click
 from libcst.codemod import CodemodContext, parallel_exec_transform_with_prettyprint

--- a/src/django_codemod/commands.py
+++ b/src/django_codemod/commands.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import List, Type
 
 import libcst as cst
 from libcst.codemod import (
@@ -12,7 +11,7 @@ from libcst.codemod import (
 class BaseCodemodCommand(VisitorBasedCodemodCommand, ABC):
     """Base class for our commands."""
 
-    transformers: List[Type[ContextAwareTransformer]]
+    transformers: list[type[ContextAwareTransformer]]
 
     def __init__(self, transformers, context: CodemodContext) -> None:
         self.transformers = transformers

--- a/src/django_codemod/path_utils.py
+++ b/src/django_codemod/path_utils.py
@@ -7,12 +7,12 @@ https://github.com/psf/black
 
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Optional
 
 from pathspec import PathSpec
 
 
-def get_sources(src: Iterable[str]) -> List[Path]:
+def get_sources(src: Iterable[str]) -> list[Path]:
     """
     Return a list of sources to codemod.
 
@@ -21,7 +21,7 @@ def get_sources(src: Iterable[str]) -> List[Path]:
     """
     root = find_project_root(src)
     gitignore = get_gitignore(root)
-    sources: Set[Path] = set()
+    sources: set[Path] = set()
     for s in src:
         p = Path(s)
         paths: Iterable[Path] = []
@@ -76,7 +76,7 @@ def find_project_root(sources: Iterable[str]) -> Path:
 def get_gitignore(root: Path) -> PathSpec:
     """Return a PathSpec matching gitignore content if present."""
     gitignore = root / ".gitignore"
-    lines: List[str] = []
+    lines: list[str] = []
     if gitignore.is_file():
         with gitignore.open() as gf:
             lines = gf.readlines()

--- a/src/django_codemod/path_utils.py
+++ b/src/django_codemod/path_utils.py
@@ -5,8 +5,9 @@ Inspired or taken from black:
 https://github.com/psf/black
 """
 
+from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Iterable, Iterator, List, Optional, Set
+from typing import List, Optional, Set
 
 from pathspec import PathSpec
 

--- a/src/django_codemod/utils/calls.py
+++ b/src/django_codemod/utils/calls.py
@@ -1,4 +1,5 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 from libcst import Arg, Call, FunctionDef, Param, parse_expression, parse_statement
 from libcst import matchers as m

--- a/src/django_codemod/visitors/base.py
+++ b/src/django_codemod/visitors/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC
 from collections.abc import Sequence
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 from libcst import (
     Arg,
@@ -47,8 +47,8 @@ class IsTryImportProvider(BatchableMetadataProvider[bool]):
 
 
 class BaseDjCodemodTransformer(ContextAwareTransformer, ABC):
-    deprecated_in: Tuple[int, int]
-    removed_in: Tuple[int, int]
+    deprecated_in: tuple[int, int]
+    removed_in: tuple[int, int]
 
 
 def module_matcher(
@@ -335,8 +335,8 @@ class BaseRenameTransformer(BaseDjCodemodTransformer, ABC):
 
 
 def clean_new_import_aliases(
-    import_aliases: List[ImportAlias],
-) -> List[ImportAlias]:
+    import_aliases: list[ImportAlias],
+) -> list[ImportAlias]:
     """Clean up a list of import aliases."""
     # Sort them
     cleaned_import_aliases = sorted(import_aliases, key=lambda n: n.evaluated_name)

--- a/src/django_codemod/visitors/base.py
+++ b/src/django_codemod/visitors/base.py
@@ -1,7 +1,8 @@
 """Module to implement base functionality."""
 
 from abc import ABC
-from typing import List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import List, Optional, Tuple, Union
 
 from libcst import (
     Arg,

--- a/src/django_codemod/visitors/crypto.py
+++ b/src/django_codemod/visitors/crypto.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from libcst import Arg, Call, Integer
 

--- a/src/django_codemod/visitors/models.py
+++ b/src/django_codemod/visitors/models.py
@@ -1,4 +1,5 @@
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Optional, Union
 
 from libcst import (
     Arg,

--- a/src/django_codemod/visitors/shortcuts.py
+++ b/src/django_codemod/visitors/shortcuts.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from libcst import Arg, Call, Name
 

--- a/src/django_codemod/visitors/signals.py
+++ b/src/django_codemod/visitors/signals.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List, Optional
+from typing import ClassVar, Optional
 
 from libcst import BaseExpression, Call, ImportFrom, ImportStar, MaybeSentinel, Module
 from libcst import matchers as m
@@ -15,7 +15,7 @@ class SignalDisconnectWeakTransformer(BaseDjCodemodTransformer):
 
     ctx_key_prefix = "SignalDisconnectWeakTransformer"
     ctx_key_call_matchers = f"{ctx_key_prefix}-call_matchers"
-    builtin_signals: ClassVar[List[str]] = [
+    builtin_signals: ClassVar[list[str]] = [
         "pre_init",
         "post_init",
         "pre_save",
@@ -31,7 +31,7 @@ class SignalDisconnectWeakTransformer(BaseDjCodemodTransformer):
     )
 
     @property
-    def disconnect_call_matchers(self) -> List[m.Call]:
+    def disconnect_call_matchers(self) -> list[m.Call]:
         return self.context.scratch.get(self.ctx_key_call_matchers, [])
 
     def add_disconnect_call_matcher(self, call_matcher: m.Call) -> None:

--- a/src/django_codemod/visitors/template_tags.py
+++ b/src/django_codemod/visitors/template_tags.py
@@ -1,4 +1,5 @@
-from typing import Generator, Optional, Sequence, Union
+from collections.abc import Generator, Sequence
+from typing import Optional, Union
 
 from libcst import (
     Assign,

--- a/src/django_codemod/visitors/timezone.py
+++ b/src/django_codemod/visitors/timezone.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from libcst import Arg, Call, Integer, parse_expression
 from libcst.codemod.visitors import AddImportsVisitor

--- a/src/django_codemod/visitors/urls.py
+++ b/src/django_codemod/visitors/urls.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from typing import Tuple
 
 from libcst import Arg, BaseExpression, Call, Name, SimpleString
 from libcst import matchers as m
@@ -86,7 +85,7 @@ class URLTransformer(BaseFuncRenameTransformer):
         return route
 
     @staticmethod
-    def parse_next_group(left_to_parse: str) -> Tuple[str, str]:
+    def parse_next_group(left_to_parse: str) -> tuple[str, str]:
         """Extract captured group info."""
         prefix, rest = left_to_parse.split("(?P<", 1)
         group, left_to_parse = rest.split(")", 1)

--- a/src/django_codemod/visitors/urls.py
+++ b/src/django_codemod/visitors/urls.py
@@ -1,4 +1,5 @@
-from typing import Sequence, Tuple
+from collections.abc import Sequence
+from typing import Tuple
 
 from libcst import Arg, BaseExpression, Call, Name, SimpleString
 from libcst import matchers as m

--- a/tests/visitors/base.py
+++ b/tests/visitors/base.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from libcst.codemod import CodemodTest
 
 from django_codemod.commands import BaseCodemodCommand
@@ -9,7 +7,7 @@ from django_codemod.visitors.base import BaseDjCodemodTransformer
 class BaseVisitorTest(CodemodTest):
     """Base test to use in all visitors tests."""
 
-    transformer: Type[BaseDjCodemodTransformer]
+    transformer: type[BaseDjCodemodTransformer]
 
     def TRANSFORM(self, context):
         """Create a command for the transformer under test."""


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

CI:
- Remove Python 3.8 from the CI testing matrix.