### PR TITLE
ci: add Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

CI:
- Add Python 3.13 to the CI testing matrix