### PR TITLE
feat: add support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         os:
           - ubuntu-latest
           - windows-latest
@@ -31,6 +32,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --no-python-downloads
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ lint.per-file-ignores."tests/**/*" = [
 ]
 lint.isort.known-first-party = [ "django_codemod", "tests" ]
 
+[tool.pyproject-fmt]
+max_supported_python = "3.14"
+
 [tool.pytest.ini_options]
 addopts = "-v -Wdefault --cov=django_codemod --cov-report=term-missing:skip-covered"
 pythonpath = [ "src" ]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Add support for Python 3.14 across CI and project metadata

Enhancements:
- Add Python 3.14 classifier to pyproject.toml

CI:
- Include Python 3.14 in the CI test matrix
- Enable allow-prereleases for actions/setup-python