### PR TITLE
chore: update RTD config to latest convention

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,21 +1,21 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
-  commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv sync --only-group docs --frozen
-    - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    python: "3.13"
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --no-dev --group docs
 
-# Build documentation in the docs directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Update Read the Docs configuration to the latest convention by bumping OS and Python versions and reorganizing build commands into new job stages

Enhancements:
- Update Read the Docs build environment from Ubuntu 22.04 to 24.04
- Upgrade the Python version from 3.12 to 3.13 in RTD config
- Restructure RTD build steps into pre_create_environment, create_environment, and install jobs
- Adjust uv commands to create the virtual environment and sync dependencies with frozen docs group