### PR TITLE
ci: migrate from pre-commit to prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: j178/prek-action@v2.0.2
+
   test:
     name: Test
     strategy:
@@ -72,6 +79,7 @@ jobs:
 
   release:
     needs:
+      - lint
       - test
       - commitlint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Ready to contribute? Here's how to set yourself up for local development.
    $ uv run pytest
    ```
 
-6. Linting is done through [prek](https://prek.j178.dev/). Provided you have the tool installed globally, you can run them all as one-off:
+6. Linting is done through [prek](https://prek.j178.dev/). Provided you have the tool installed globally, you can run them all as a one-off:
 
    ```shell
    $ prek run -a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,16 +66,16 @@ Ready to contribute? Here's how to set yourself up for local development.
    $ uv run pytest
    ```
 
-6. Linting is done through [pre-commit](https://pre-commit.com). Provided you have the tool installed globally, you can run them all as one-off:
+6. Linting is done through [prek](https://prek.j178.dev/). Provided you have the tool installed globally, you can run them all as one-off:
 
    ```shell
-   $ pre-commit run -a
+   $ prek run -a
    ```
 
    Or better, install the hooks once and have them run automatically each time you commit:
 
    ```shell
-   $ pre-commit install
+   $ prek install -f
    ```
 
 7. Commit your changes and push your branch to GitHub:
@@ -86,7 +86,7 @@ Ready to contribute? Here's how to set yourself up for local development.
    $ git push origin name-of-your-bugfix-or-feature
    ```
 
-   Note: the commit message should follow [the conventional commits](https://www.conventionalcommits.org). We run [`commitlint` on CI](https://github.com/marketplace/actions/commit-linter) to validate it, and if you've installed pre-commit hooks at the previous step, the message will be checked at commit time.
+   Note: the commit message should follow [the conventional commits](https://www.conventionalcommits.org). We run [`commitlint` on CI](https://github.com/marketplace/actions/commit-linter) to validate it, and if you've installed prek hooks at the previous step, the message will be checked at commit time.
 
 8. Submit a pull request through the GitHub website or using the GitHub CLI (if you have it installed):
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
   <a href="https://github.com/astral-sh/ruff">
     <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff">
   </a>
-  <a href="https://github.com/pre-commit/pre-commit">
-    <img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=flat-square" alt="pre-commit">
+  <a href="https://github.com/j178/prek">
+    <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json" alt="prek">
   </a>
 </p>
 <p align="center">


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Migrate linting setup from pre-commit to prek and integrate linting into the CI workflow.

Enhancements:
- Add a dedicated lint job to the CI workflow using prek and make the release job depend on it.
- Update README badge to advertise prek instead of pre-commit.
- Revise contributing guide to describe local linting and commit-time hooks using prek rather than pre-commit.