### PR TITLE
chore: migrate from mypy to ty

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,0 @@
-tasks:
-  - command: |
-      pip install uv
-      PIP_USER=false uv sync
-  - command: |
-      pip install pre-commit
-      pre-commit install
-      PIP_USER=false pre-commit install-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,11 @@ repos:
     hooks:
       - id: commitizen
         stages: [commit-msg]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+  - repo: local
     hooks:
-      - id: mypy
+      - id: local-ty
+        name: ty check
+        entry: uv run ty check
+        require_serial: true
+        language: system
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
   "pytest>=9,<10",
   "pytest-cov>=7,<8",
   "pytest-mock>=3.3,<4",
+  "ty==0.0.31",
 ]
 docs = [
   "furo>=2023.5.20; python_version>='3.11'",
@@ -97,13 +98,8 @@ lint.isort.known-first-party = [ "django_codemod", "tests" ]
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-[tool.mypy]
-# suppress errors about unsatisfied imports
-ignore_missing_imports = true
-no_implicit_optional = true
-# ensure all execution paths are returning
-warn_no_return = true
-show_error_codes = true
+[tool.ty]
+terminal.error-on-warning = true
 
 [tool.pytest]
 minversion = "9.0"

--- a/src/django_codemod/cli.py
+++ b/src/django_codemod/cli.py
@@ -203,7 +203,7 @@ def call_command(command_instance: BaseCodemodCommand, files: list[Path]):
     click.echo(f" - Failed to codemod {result.failures} files.")
     click.echo(f" - {result.warnings} warnings were generated.")
     if result.failures > 0:
-        raise click.exceptions.Exit(1)
+        raise SystemExit(1)
 
 
 @djcodemod.command("list")

--- a/src/django_codemod/cli.py
+++ b/src/django_codemod/cli.py
@@ -5,6 +5,7 @@ from operator import attrgetter
 from pathlib import Path
 
 import rich_click as click
+from click.exceptions import Exit
 from libcst.codemod import CodemodContext, parallel_exec_transform_with_prettyprint
 from rich.console import Console
 from rich.markdown import Markdown
@@ -203,7 +204,7 @@ def call_command(command_instance: BaseCodemodCommand, files: list[Path]):
     click.echo(f" - Failed to codemod {result.failures} files.")
     click.echo(f" - {result.warnings} warnings were generated.")
     if result.failures > 0:
-        raise SystemExit(1)
+        raise Exit(1)
 
 
 @djcodemod.command("list")

--- a/src/django_codemod/visitors/base.py
+++ b/src/django_codemod/visitors/base.py
@@ -38,7 +38,7 @@ class IsTryImportProvider(BatchableMetadataProvider[bool]):
     def visit_Try(self, node: Try) -> None:
         self.try_level += 1
 
-    def leave_Try(self, node: Try) -> None:
+    def leave_Try(self, original_node: Try) -> None:
         self.try_level -= 1
 
     def visit_ImportFrom(self, node: ImportFrom) -> None:
@@ -267,7 +267,7 @@ class BaseRenameTransformer(BaseDjCodemodTransformer, ABC):
 
     def resolve_scope(self, node: CSTNode) -> Scope:
         scopes_map = self.context.wrapper.resolve(ScopeProvider)  # type: ignore
-        return scopes_map[node]  # type: ignore
+        return scopes_map[node]
 
     def save_import_scope(self, import_from: ImportFrom) -> None:
         scope = self.resolve_scope(import_from)

--- a/src/django_codemod/visitors/models.py
+++ b/src/django_codemod/visitors/models.py
@@ -134,9 +134,13 @@ class ModelsPermalinkTransformer(BaseDjCodemodTransformer):
     def leave_Return(
         self, original_node: Return, updated_node: Return
     ) -> BaseSmallStatement | FlattenSentinel[BaseSmallStatement] | RemovalSentinel:
-        if self.visiting_permalink_method and m.matches(
-            updated_node.value,
-            m.Tuple(),  # type: ignore
+        if (
+            self.visiting_permalink_method
+            and updated_node.value is not None
+            and m.matches(
+                updated_node.value,
+                m.Tuple(),
+            )
         ):
             elem_0, *elem_1_3 = updated_node.value.elements[:3]  # type: ignore
             args = (

--- a/src/django_codemod/visitors/signals.py
+++ b/src/django_codemod/visitors/signals.py
@@ -89,7 +89,7 @@ class SignalDisconnectWeakTransformer(BaseDjCodemodTransformer):
                     should_change = True
                 else:
                     updated_args.append(arg)
-                last_comma = arg.comma  # type: ignore
+                last_comma = arg.comma
             if should_change:
                 # Make sure the end of line is formatted as initially
                 updated_args[-1] = updated_args[-1].with_changes(comma=last_comma)

--- a/src/django_codemod/visitors/template_tags.py
+++ b/src/django_codemod/visitors/template_tags.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator, Sequence
 
 from libcst import (

--- a/src/django_codemod/visitors/urls.py
+++ b/src/django_codemod/visitors/urls.py
@@ -57,6 +57,8 @@ class URLTransformer(BaseFuncRenameTransformer):
             raise PatternNotSupported()
         # Extract the URL pattern from the first argument
         pattern = first_arg.value.evaluated_value
+        if not isinstance(pattern, str):
+            raise PatternNotSupported()
         # If we reach this point, we might be able to use `path()`
         call = self.build_path_call(pattern, other_args)
         AddImportsVisitor.add_needed_import(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,7 +145,7 @@ def test_call_command_failure(command_instance, mocker):
         successes=0, failures=1, warnings=0, skips=0
     )
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(SystemExit):
         cli.call_command(command_instance, [Path(".")])
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,7 @@ def test_call_command_success(command_instance, mocker):
         successes=1, failures=0, warnings=0, skips=0
     )
 
-    result = cli.call_command(command_instance, ".")
+    result = cli.call_command(command_instance, [Path(".")])
 
     assert result is None
 
@@ -146,7 +146,7 @@ def test_call_command_failure(command_instance, mocker):
     )
 
     with pytest.raises(click.exceptions.Exit):
-        cli.call_command(command_instance, ".")
+        cli.call_command(command_instance, [Path(".")])
 
 
 @pytest.mark.usefixtures("get_sources_mocked")
@@ -160,7 +160,7 @@ def test_call_command_interrupted(command_instance, mocker):
     )
 
     with pytest.raises(click.Abort):
-        cli.call_command(command_instance, ".")
+        cli.call_command(command_instance, [Path(".")])
 
 
 def _verify_mapping(mapping, version_attr):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import click
 import pytest
+from click.exceptions import Exit
 from click.testing import CliRunner
 from libcst.codemod import CodemodContext, ParallelTransformResult
 
@@ -145,7 +146,7 @@ def test_call_command_failure(command_instance, mocker):
         successes=0, failures=1, warnings=0, skips=0
     )
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(Exit):
         cli.call_command(command_instance, [Path(".")])
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -323,6 +323,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "ty" },
 ]
 docs = [
     { name = "furo", marker = "python_full_version >= '3.11'" },
@@ -346,6 +347,7 @@ dev = [
     { name = "pytest", specifier = ">=9,<10" },
     { name = "pytest-cov", specifier = ">=7,<8" },
     { name = "pytest-mock", specifier = ">=3.3,<4" },
+    { name = "ty", specifier = "==0.0.31" },
 ]
 docs = [
     { name = "furo", marker = "python_full_version >= '3.11'", specifier = ">=2023.5.20" },
@@ -1064,6 +1066,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619, upload-time = "2026-04-15T15:47:59.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749, upload-time = "2026-04-15T15:48:14.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012, upload-time = "2026-04-15T15:48:22.554Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790, upload-time = "2026-04-15T15:47:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286, upload-time = "2026-04-15T15:48:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824, upload-time = "2026-04-15T15:48:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864, upload-time = "2026-04-15T15:48:08.473Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401, upload-time = "2026-04-15T15:48:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903, upload-time = "2026-04-15T15:47:55.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624, upload-time = "2026-04-15T15:47:51.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089, upload-time = "2026-04-15T15:47:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315, upload-time = "2026-04-15T15:48:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473, upload-time = "2026-04-15T15:48:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785, upload-time = "2026-04-15T15:48:10.754Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657, upload-time = "2026-04-15T15:48:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258, upload-time = "2026-04-15T15:47:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392, upload-time = "2026-04-15T15:47:57.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Migrate the project from mypy to ty for static type checking and integrate it into the development workflow.

Enhancements:
- Replace the mypy pre-commit hook with a local ty-based type checking hook configured to run via uv.
- Add the ty package as a development dependency and configure its settings to treat warnings as errors.

Chores:
- Remove obsolete mypy configuration and associated project files, including the Gitpod configuration file.