### PR TITLE
feat: add support for Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
         os:
           - ubuntu-latest
           - windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
@@ -96,7 +97,7 @@ lint.per-file-ignores."tests/**/*" = [
 lint.isort.known-first-party = [ "django_codemod", "tests" ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.ty]
 terminal.error-on-warning = true


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Add Python 3.15 support across packaging metadata and CI.

New Features:
- Declare Python 3.15 as a supported runtime in project metadata.

Build:
- Update tooling configuration to treat Python 3.15 as the maximum supported version.

CI:
- Extend the CI test matrix to run against Python 3.15.